### PR TITLE
Scheduled future strikes

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,21 @@ sequenceDiagram
     end
 ```
 
+### automatic future block time strike creation
+
+Blocktime service provides automaticall creation of future strikes during handling latest confirmed block event. See oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeScheduledFutureStrikeCreation.hs for implementation. Current implementation ensures, that there are future strike exist in range `[ minimumFutureStrikeHeight, maximumFutureStrikeHeight]`, where:
+
+```haskell
+  minimumFutureStrikeHeight = blockHeaderHeight currentTip + configBlockTimeStrikeFutureGuessMinimumBlockAheadCurrentTip
+  maximumFutureStrikeHeight = blockHeaderHeight currentTip + configBlockTimeFutureStrikeShouldExistsAheadCurrentTip
+```
+
+```mermaid
+sequenceDiagram
+    blockspan service -> blocktime service: current tip event message (websocket)
+    blocktime service ->> blocktime service: ensureFutureStrikeExistsAhead(currentTip)
+```
+
 ### viewing list of block time strikes
 
 ```mermaid

--- a/oe-account-service/op-energy-account-service/op-energy-account-service.cabal
+++ b/oe-account-service/op-energy-account-service/op-energy-account-service.cabal
@@ -60,6 +60,7 @@ library
                    , OpEnergy.BlockTimeStrike.Server.V1.Class
                    , OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeService
                    , OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeGuessService
+                   , OpEnergy.BlockTimeStrike.Server.V1.BlockTimeScheduledFutureStrikeCreation
                    , Data.Text.Show
     build-depends:    base ^>=4.15.1.0
                     , aeson

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/Account/Server/V1/Config.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/Account/Server/V1/Config.hs
@@ -61,6 +61,8 @@ data Config = Config
     -- ^ this value defines the minimum ahead of future strike guess to require. It should be at least 6, as confirmed current tip is 6 blocks behind unconfirmed tip
   , configBlockspanURL :: BaseUrl
     -- ^ defines URL to blockspan api instance. Used to get block header info at block discovery
+  , configBlockTimeFutureStrikeShouldExistsAheadCurrentTip :: Positive Int
+    -- ^ defines how many blocks ahead of current tip there should exist a future strike. Effectively, this means, that there should exist future strikes for a range [ currentTip + configBlockTimeStrikeFutureGuessMinimumBlockAheadCurrentTip; currentTip + configBlockTimeStrikeFutureGuessMinimumBlockAheadCurrentTip + configBlockTimeFutureStrikeShouldExistsAheadCurrentTip ]
   }
   deriving Show
 instance FromJSON Config where
@@ -82,6 +84,7 @@ instance FromJSON Config where
     <*> ((v .:? "BLOCKTIME_STRIKE_BLOCKSPAN_WEBSOCKET_API_URL" .!= (showBaseUrl $ configBlockTimeStrikeBlockSpanWebsocketAPIURL defaultConfig)) >>= parseBaseUrl)
     <*> ( v .:? "BLOCKTIME_STRIKE_FUTURE_GUESS_MINIMUM_BLOCKS_AHEAD_CURRENT_TIP" .!= (configBlockTimeStrikeFutureGuessMinimumBlockAheadCurrentTip defaultConfig))
     <*> ((v .:? "BLOCKSPAN_API_URL" .!= (showBaseUrl $ configBlockspanURL defaultConfig)) >>= parseBaseUrl)
+    <*> ( v .:? "BLOCKTIME_FUTURE_STRIKE_SHOULD_EXISTS_AHEAD_CURRENT_TIP" .!= (configBlockTimeFutureStrikeShouldExistsAheadCurrentTip defaultConfig))
 
 -- need to get Key from json, which represented as base64-encoded string
 instance FromJSON Key where
@@ -110,6 +113,7 @@ defaultConfig = Config
   , configBlockTimeStrikeBlockSpanWebsocketAPIURL = BaseUrl Http "127.0.0.1" 8999 "/api/v1/ws"
   , configBlockTimeStrikeFutureGuessMinimumBlockAheadCurrentTip = 6
   , configBlockspanURL = BaseUrl Http "127.0.0.1" 8999 ""
+  , configBlockTimeFutureStrikeShouldExistsAheadCurrentTip = 12
   }
 
 getConfigFromEnvironment :: IO Config

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/Account/Server/V1/Metrics.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/Account/Server/V1/Metrics.hs
@@ -38,6 +38,7 @@ data MetricsState = MetricsState
   , mgetBlockTimeStrikeFuture :: P.Histogram
   , createBlockTimeStrikeFutureGuess :: P.Histogram
   , mgetBlockTimeStrikePast :: P.Histogram
+  , ensureFutureStrikeExistsAhead :: P.Histogram
   }
 
 -- | constructs default state with given config and DB pool
@@ -61,7 +62,8 @@ initMetrics _config = do
   getBlockTimeStrikeFutureGuesses <- P.register $ P.histogram (P.Info "getBlockTimeStrikeFutureGuesses" "") microBuckets
   mgetBlockTimeStrikeFuture <- P.register $ P.histogram (P.Info "mgetBlockTimeStrikeFuture" "") microBuckets
   createBlockTimeStrikeFutureGuess <- P.register $ P.histogram (P.Info "createBlockTimeStrikeFutureGuess" "") microBuckets
-  mgetBlockTimeStrikePast <- P.register $ P.histogram (P.Info "mgetBlockTimeStrikePast " "") microBuckets
+  mgetBlockTimeStrikePast <- P.register $ P.histogram (P.Info "mgetBlockTimeStrikePast" "") microBuckets
+  ensureFutureStrikeExistsAhead <- P.register $ P.histogram (P.Info "ensureFutureStrikeExistsAhead" "") microBuckets
   _ <- P.register P.ghcMetrics
   _ <- P.register P.procMetrics
   return $ MetricsState
@@ -84,6 +86,7 @@ initMetrics _config = do
     , mgetBlockTimeStrikeFuture = mgetBlockTimeStrikeFuture
     , createBlockTimeStrikeFutureGuess = createBlockTimeStrikeFutureGuess
     , mgetBlockTimeStrikePast = mgetBlockTimeStrikePast
+    , ensureFutureStrikeExistsAhead = ensureFutureStrikeExistsAhead
     }
   where
     microBuckets = [ 0.0000001 -- 100 nanoseconds

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeScheduledFutureStrikeCreation.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeScheduledFutureStrikeCreation.hs
@@ -1,0 +1,82 @@
+-- | This module's main purpose is to contain a scheduled routine to create future time strikes automatically.
+{-# LANGUAGE TemplateHaskell          #-}
+module OpEnergy.BlockTimeStrike.Server.V1.BlockTimeScheduledFutureStrikeCreation
+  ( maybeCreateFutureStrikes
+  ) where
+
+import qualified Data.List as List
+import Data.Time.Clock (getCurrentTime)
+import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds)
+import Control.Monad.Reader(ask)
+import Control.Monad.IO.Class(MonadIO, liftIO)
+import           Control.Monad.Logger( logInfo, logDebug)
+import Control.Monad(forM_, when)
+
+import           Database.Persist.Postgresql
+import           Prometheus(MonadMonitor)
+import qualified Prometheus as P
+
+import           Data.OpEnergy.API.V1.Block
+import           Data.OpEnergy.Account.API.V1.BlockTimeStrike
+import           Data.OpEnergy.API.V1.Positive
+import           Data.OpEnergy.API.V1.Natural
+import           OpEnergy.Account.Server.V1.Class (AppT, State(..), runLogging)
+import           OpEnergy.Account.Server.V1.Config
+import qualified OpEnergy.Account.Server.V1.Metrics as Metrics(MetricsState(..))
+import           Data.Text.Show
+
+-- | This function is being called when latest confirmed block had been discovered. You should expect, that it can be called by recieving notification from the blockspan service either at discover or at a time of connection of block time service to blockspan service. So it is expected, that it will run at each restart of the blockspan service or at reconnection to blockspan service or at blocktime service restart.
+maybeCreateFutureStrikes
+  :: ( MonadIO m
+     , MonadMonitor m
+     )
+  => BlockHeader
+  -> AppT m ()
+maybeCreateFutureStrikes currentTip = do
+  ensureFutureStrikeExistsAhead currentTip
+
+-- | this function creates necessary future strikes if they haven't been created yet as it tries to be idempotent.
+-- NOTE: currently, we use CurrentTip + Config.configBlockTimeStrikeFutureGuessMinimumBlockAheadCurrentTip as the minimum block height for a future strike.
+ensureFutureStrikeExistsAhead
+  :: ( MonadIO m
+     , MonadMonitor m
+     )
+  => BlockHeader
+  -> AppT m ()
+ensureFutureStrikeExistsAhead currentTip = do
+  State{ config = Config
+         { configBlockTimeFutureStrikeShouldExistsAheadCurrentTip = configBlockTimeFutureStrikeShouldExistsAheadCurrentTip
+         , configBlockTimeStrikeFutureGuessMinimumBlockAheadCurrentTip = configBlockTimeStrikeFutureGuessMinimumBlockAheadCurrentTip
+         }
+       , accountDBPool = pool
+       , metrics = Metrics.MetricsState { Metrics.ensureFutureStrikeExistsAhead = ensureFutureStrikeExistsAhead
+                                        }
+       } <- ask
+  P.observeDuration ensureFutureStrikeExistsAhead $ do
+    let minimumFutureStrikeHeight = blockHeaderHeight currentTip + naturalFromPositive configBlockTimeStrikeFutureGuessMinimumBlockAheadCurrentTip
+        maximumFutureStrikeHeight = blockHeaderHeight currentTip + naturalFromPositive configBlockTimeFutureStrikeShouldExistsAheadCurrentTip
+    runLogging $ $(logDebug) ("ensureFutureStrikeExistsAhead: currentTip: " <> tshow currentTip <>  ", min/max: " <> tshow [minimumFutureStrikeHeight, maximumFutureStrikeHeight])
+    nonExistentBlockHeights <- liftIO $ do
+      now <- getCurrentTime
+      flip runSqlPersistMPool pool $ do
+        futureStrikesE <- selectList
+          [ BlockTimeStrikeFutureBlock >=. minimumFutureStrikeHeight
+          , BlockTimeStrikeFutureBlock <=. maximumFutureStrikeHeight
+          ] []
+        let futureStrikes = List.map (\(Entity _ strike) -> blockTimeStrikeFutureBlock strike) futureStrikesE
+        let nonExistentStrikeHeights = List.filter
+              (\height-> height `notElem` futureStrikes)
+              [ minimumFutureStrikeHeight .. maximumFutureStrikeHeight ]
+        forM_ nonExistentStrikeHeights $ \height-> do
+          insert (BlockTimeStrikeFuture { blockTimeStrikeFutureBlock = height
+                                        , blockTimeStrikeFutureNlocktime =
+                                          fromIntegral
+                                          $ blockHeaderMediantime currentTip
+                                          + fromIntegral ((fromNatural (height - blockHeaderHeight currentTip)) * 600) -- assume 10 minutes time slices for nlocktime
+                                        , blockTimeStrikeFutureCreationTime = utcTimeToPOSIXSeconds now
+                                        })
+
+        return nonExistentStrikeHeights
+    when (List.length nonExistentBlockHeights > 0) $ do
+      runLogging $ $(logInfo) ("ensureFutureStrikeExistsAhead: created future strikes: " <> (tshow nonExistentBlockHeights))
+

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeGuessService.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeGuessService.hs
@@ -250,7 +250,12 @@ calculateResultsLoop = forever $ do
                 -- remove guess
                 delete guessId
               -- remove observedBlock
-              delete observedBlockKey
+              _ <- delete observedBlockKey
+              liftIO $ runAppT state $ do
+                runLogging $ $(logDebug) $ "calculateResultsLoop: removed observedBlockKey "
+                  <> tshow (blockTimeStrikePastBlock pastStrike) <> " , "
+                  <> tshow (blockTimeStrikeFutureBlock futureStrike)
+                  <> ", observedBlockKey : " <> tshow observedBlockKey
               -- mark blocktime strike future as ready to be removed
               _ <- insert $ BlockTimeStrikeFutureReadyToRemove
                 { blockTimeStrikeFutureReadyToRemoveFutureStrike = (blockTimeStrikeFutureObservedBlockFutureStrike observedBlock)


### PR DESCRIPTION
This PR introduces scheduled creation of future strikes by block time.
Current implementation provides idempotent procedure, which ensures that there exist future strike in a range [ currentTip + configBlockTimeStrikeFutureGuessMinimumBlockAheadCurrentTip ; currentTip + configBlockTimeFutureStrikeShouldExistsAheadCurrentTip ].

the initial task was to implement such routine as some sort of cron job, but it requires implementation of new API endpoints for both blockspan service (to get latest confirmed tip) and blocktime strike service (to create new strike without authentication token) and actively polling blockspan service in order to understand if there should be new future strikes creates. Current implementation, in it's turn, runs only at receiving latest confirmed block event from blockspan service.
Let me know if the task was to implement it as internal API specifically

Note that configBlockTimeStrikeFutureGuessMinimumBlockAheadCurrentTip is not a part of current implementation. It's purpose is to be a guard to only accept guesses for future strikes with such offset. (for example of reasoning: currentTip + 1 can be an easy guess and we may want to have some offset to increase difficulty of guess).