### PR TITLE
refactor blocktime api get account token from the header instead of body

### DIFF
--- a/oe-account-service/op-energy-account-api/src/Data/OpEnergy/Account/API/V1.hs
+++ b/oe-account-service/op-energy-account-api/src/Data/OpEnergy/Account/API/V1.hs
@@ -56,7 +56,7 @@ type BlockTimeV1API
 
   :<|> "future"
     :> "strike"
-    :> ReqBody '[JSON] AccountToken -- require authentication
+    :> Header' '[Required, Strict, Description "Account token gotten from /login or /register" ] "AccountToken" AccountToken -- require authentication
     :> Description "returns list of the future time strikes. Requires authentication."
     :> Post '[JSON] [BlockTimeStrikeFuture]
 
@@ -70,7 +70,7 @@ type BlockTimeV1API
 
   :<|> "future"
     :> "strike"
-    :> ReqBody '[JSON] AccountToken -- require authentication
+    :> Header' '[Required, Strict, Description "Account token gotten from /login or /register" ] "AccountToken" AccountToken -- require authentication
     :> Capture "BlockHeight" BlockHeight
     :> Capture "nLockTime" (Natural Int)
     :> Description "Creates new future time strike by given BlockHeight and nLockTime. Requires authentication. Where: BlockHeight - height of the block in the future. It is expected, that it should be at least at 12 block in the future than current confirmed tip. nLockTime is a POSIX time in the future."
@@ -79,7 +79,7 @@ type BlockTimeV1API
   :<|> "future"
     :> "strike"
     :> "guess"
-    :> ReqBody '[JSON] AccountToken -- require authentication
+    :> Header' '[Required, Strict, Description "Account token gotten from /login or /register" ] "AccountToken" AccountToken -- require authentication
     :> Capture "BlockHeight" BlockHeight
     :> Capture "nLockTime" (Natural Int)
     :> Description "returns list of the guesses for a given future time strike. Requires authentication."
@@ -97,7 +97,7 @@ type BlockTimeV1API
   :<|> "future"
     :> "strike"
     :> "guess"
-    :> ReqBody '[JSON] AccountToken -- require authentication
+    :> Header' '[Required, Strict, Description "Account token gotten from /login or /register" ] "AccountToken" AccountToken -- require authentication
     :> Capture "BlockHeight" BlockHeight
     :> Capture "nLockTime" (Natural Int)
     :> Capture "guess" SlowFast
@@ -106,7 +106,7 @@ type BlockTimeV1API
 
   :<|> "past"
     :> "strike"
-    :> ReqBody '[JSON] AccountToken -- require authentication
+    :> Header' '[Required, Strict, Description "Account token gotten from /login or /register" ] "AccountToken" AccountToken -- require authentication
     :> Description "returns list of past strikes, that have been already processed. Requires authentication. Time strike becomes \"past\" when it becomes confirmed and you can think about it as archived strike, that had been processed and now being kept as history"
     :> Post '[JSON] [BlockTimeStrikePast]
 
@@ -127,7 +127,7 @@ type BlockTimeV1API
   :<|> "past"
     :> "strike"
     :> "guess"
-    :> ReqBody '[JSON] AccountToken -- require authentication
+    :> Header' '[Required, Strict, Description "Account token gotten from /login or /register" ] "AccountToken" AccountToken -- require authentication
     :> Capture "BlockHeight" BlockHeight
     :> Capture "nLockTime" (Natural Int)
     :> Description "returns results for the given blocktime strike in the past. Requires authentication. Time strike becomes \"past\" when it becomes confirmed and you can think about it as archived strike, that had been processed and now being kept as history. 'Guess' becomes a 'result' when blocktime strike becomes confirmed and processed."

--- a/oe-account-service/op-energy-account-api/src/Data/OpEnergy/Account/API/V1.hs
+++ b/oe-account-service/op-energy-account-api/src/Data/OpEnergy/Account/API/V1.hs
@@ -56,12 +56,6 @@ type BlockTimeV1API
 
   :<|> "future"
     :> "strike"
-    :> Header' '[Required, Strict, Description "Account token gotten from /login or /register" ] "AccountToken" AccountToken -- require authentication
-    :> Description "returns list of the future time strikes. Requires authentication."
-    :> Post '[JSON] [BlockTimeStrikeFuture]
-
-  :<|> "future"
-    :> "strike"
     :> "page"
     :> QueryParam' '[Optional, Strict, Description "defines page count to get" ] "page" (Natural Int)
     :> QueryParam' '[Optional, Strict, Description "possible filter as a string in JSON format. you can pass any combination of it's unique fields to build a filter" ] "filter" (FilterRequest BlockTimeStrikeFuture BlockTimeStrikeFutureFilter)
@@ -75,15 +69,6 @@ type BlockTimeV1API
     :> Capture "nLockTime" (Natural Int)
     :> Description "Creates new future time strike by given BlockHeight and nLockTime. Requires authentication. Where: BlockHeight - height of the block in the future. It is expected, that it should be at least at 12 block in the future than current confirmed tip. nLockTime is a POSIX time in the future."
     :> Post '[JSON] ()
-
-  :<|> "future"
-    :> "strike"
-    :> "guess"
-    :> Header' '[Required, Strict, Description "Account token gotten from /login or /register" ] "AccountToken" AccountToken -- require authentication
-    :> Capture "BlockHeight" BlockHeight
-    :> Capture "nLockTime" (Natural Int)
-    :> Description "returns list of the guesses for a given future time strike. Requires authentication."
-    :> Post '[JSON] [BlockTimeStrikeGuessPublic]
 
   :<|> "future"
     :> "strike"
@@ -106,32 +91,11 @@ type BlockTimeV1API
 
   :<|> "past"
     :> "strike"
-    :> Header' '[Required, Strict, Description "Account token gotten from /login or /register" ] "AccountToken" AccountToken -- require authentication
-    :> Description "returns list of past strikes, that have been already processed. Requires authentication. Time strike becomes \"past\" when it becomes confirmed and you can think about it as archived strike, that had been processed and now being kept as history"
-    :> Post '[JSON] [BlockTimeStrikePast]
-
-  :<|> "past"
-    :> "strikeExt"
-    :> QueryParam' '[Optional, Strict, Description "defines page count to get" ] "page" (Natural Int)
-    :> Description "DEPRECATED: use /api/v1/past/strike/page instead"
-    :> Get '[JSON] (PagingResult BlockTimeStrikePastPublic)
-
-  :<|> "past"
-    :> "strike"
     :> "page"
     :> QueryParam' '[Optional, Strict, Description "defines page count to get" ] "page" (Natural Int)
     :> QueryParam' '[Optional, Strict, Description "possible filter as a string in JSON format. you can pass any combination of it's unique fields to build a filter" ] "filter" (FilterRequest BlockTimeStrikePast BlockTimeStrikePastFilter)
     :> Description "returns list of past strikes, that have been already processed. Results are ordered by block mediantime in descending order. Time strike becomes \"past\" when it becomes confirmed and you can think about it as archived strike, that had been processed and now being kept as history"
     :> Get '[JSON] (PagingResult BlockTimeStrikePastPublic)
-
-  :<|> "past"
-    :> "strike"
-    :> "guess"
-    :> Header' '[Required, Strict, Description "Account token gotten from /login or /register" ] "AccountToken" AccountToken -- require authentication
-    :> Capture "BlockHeight" BlockHeight
-    :> Capture "nLockTime" (Natural Int)
-    :> Description "returns results for the given blocktime strike in the past. Requires authentication. Time strike becomes \"past\" when it becomes confirmed and you can think about it as archived strike, that had been processed and now being kept as history. 'Guess' becomes a 'result' when blocktime strike becomes confirmed and processed."
-    :> Post '[JSON] [BlockTimeStrikeGuessResultPublic]
 
   :<|> "past"
     :> "strike"

--- a/oe-account-service/op-energy-account-api/src/Data/OpEnergy/Account/API/V1/Account.hs
+++ b/oe-account-service/op-energy-account-api/src/Data/OpEnergy/Account/API/V1/Account.hs
@@ -39,6 +39,7 @@ import qualified Data.ByteString as BS (pack)
 import           Database.Persist.TH
 import           Database.Persist
 import           Database.Persist.Sql
+import           Servant.API
 
 import           Data.OpEnergy.Account.API.V1.UUID
 import           Data.OpEnergy.Account.API.V1.Hash
@@ -80,6 +81,8 @@ instance ToParamSchema AccountToken where
   toParamSchema _ = mempty
     & type_ ?~ SwaggerString
     & format ?~ unAccountToken defaultAccountToken
+instance FromHttpApiData AccountToken where
+  parseUrlPiece = everifyAccountToken
 
 defaultAccountToken :: AccountToken
 defaultAccountToken = verifyAccountToken "h+3b0A7XIfbmjg=="

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/Account/Server/V1/Metrics.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/Account/Server/V1/Metrics.hs
@@ -37,14 +37,6 @@ data MetricsState = MetricsState
   , accountMgetPersonByHashedSecretUpdatingTokenCookie :: P.Histogram
   , accountMgetPersonByHashedSecretTokenCookie :: P.Histogram
   , accountMgetPersonByAccountToken :: P.Histogram
-  , getBlockTimeStrikeFuture :: P.Histogram
-  , createBlockTimeStrikeFuture :: P.Histogram
-  , getBlockTimeStrikePast :: P.Histogram
-  , getBlockTimeStrikeFutureGuesses :: P.Histogram
-  , mgetBlockTimeStrikeFuture :: P.Histogram
-  , createBlockTimeStrikeFutureGuess :: P.Histogram
-  , mgetBlockTimeStrikePast :: P.Histogram
-  , ensureFutureStrikeExistsAhead :: P.Histogram
   , dynamicHistograms :: TVar (Map Text P.Histogram)
   }
 
@@ -63,14 +55,6 @@ initMetrics _config = do
   accountMgetPersonByHashedSecretUpdatingTokenCookie <- P.register $ P.histogram (P.Info "accountMgetPersonByHashedSecretUpdatingTokenCookie" "") microBuckets
   accountMgetPersonByHashedSecretTokenCookie <- P.register $ P.histogram (P.Info "accountMgetPersonByHashedSecretTokenCookie" "") microBuckets
   accountMgetPersonByAccountToken <- P.register $ P.histogram (P.Info "accountMgetPersonByAccountToken" "") microBuckets
-  getBlockTimeStrikeFuture <- P.register $ P.histogram (P.Info "getBlockTimeStrikeFuture" "") microBuckets
-  createBlockTimeStrikeFuture <- P.register $ P.histogram (P.Info "createBlockTimeStrikeFuture" "") microBuckets
-  getBlockTimeStrikePast <- P.register $ P.histogram (P.Info "getBlockTimeStrikePast" "") microBuckets
-  getBlockTimeStrikeFutureGuesses <- P.register $ P.histogram (P.Info "getBlockTimeStrikeFutureGuesses" "") microBuckets
-  mgetBlockTimeStrikeFuture <- P.register $ P.histogram (P.Info "mgetBlockTimeStrikeFuture" "") microBuckets
-  createBlockTimeStrikeFutureGuess <- P.register $ P.histogram (P.Info "createBlockTimeStrikeFutureGuess" "") microBuckets
-  mgetBlockTimeStrikePast <- P.register $ P.histogram (P.Info "mgetBlockTimeStrikePast" "") microBuckets
-  ensureFutureStrikeExistsAhead <- P.register $ P.histogram (P.Info "ensureFutureStrikeExistsAhead" "") microBuckets
   _ <- P.register P.ghcMetrics
   _ <- P.register P.procMetrics
   tmap <- liftIO $ STM.newTVarIO (Map.empty)
@@ -87,14 +71,6 @@ initMetrics _config = do
     , accountMgetPersonByHashedSecretUpdatingTokenCookie = accountMgetPersonByHashedSecretUpdatingTokenCookie
     , accountMgetPersonByHashedSecretTokenCookie = accountMgetPersonByHashedSecretTokenCookie
     , accountMgetPersonByAccountToken = accountMgetPersonByAccountToken
-    , getBlockTimeStrikeFuture = getBlockTimeStrikeFuture
-    , createBlockTimeStrikeFuture = createBlockTimeStrikeFuture
-    , getBlockTimeStrikePast = getBlockTimeStrikePast
-    , getBlockTimeStrikeFutureGuesses = getBlockTimeStrikeFutureGuesses
-    , mgetBlockTimeStrikeFuture = mgetBlockTimeStrikeFuture
-    , createBlockTimeStrikeFutureGuess = createBlockTimeStrikeFutureGuess
-    , mgetBlockTimeStrikePast = mgetBlockTimeStrikePast
-    , ensureFutureStrikeExistsAhead = ensureFutureStrikeExistsAhead
     , dynamicHistograms = tmap
     }
 

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1.hs
@@ -51,16 +51,11 @@ import qualified OpEnergy.BlockTimeStrike.Server.V1.Class as BlockTime(State(..)
 
 blockTimeServer :: ServerT BlockTimeV1API (AppT Handler)
 blockTimeServer = websocketHandler
-  :<|> OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeService.getBlockTimeStrikeFuture
   :<|> OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeService.getBlockTimeStrikeFuturePage
   :<|> createBlockTimeStrikeFuture
-  :<|> OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeGuessService.getBlockTimeStrikeFutureGuesses
   :<|> OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeGuessService.getBlockTimeStrikeFutureGuessesPage
   :<|> OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeGuessService.createBlockTimeStrikeFutureGuess
-  :<|> getBlockTimeStrikePast
-  :<|> getBlockTimeStrikePastExt
   :<|> getBlockTimeStrikePastPage
-  :<|> OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeGuessService.getBlockTimeStrikeGuessResults
   :<|> OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeGuessService.getBlockTimeStrikeGuessResultsPage
   :<|> oeGitHashGet
   where

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeScheduledFutureStrikeCreation.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeScheduledFutureStrikeCreation.hs
@@ -14,15 +14,13 @@ import Control.Monad(forM_, when)
 
 import           Database.Persist.Postgresql
 import           Prometheus(MonadMonitor)
-import qualified Prometheus as P
 
 import           Data.OpEnergy.API.V1.Block
 import           Data.OpEnergy.Account.API.V1.BlockTimeStrike
 import           Data.OpEnergy.API.V1.Positive
 import           Data.OpEnergy.API.V1.Natural
-import           OpEnergy.Account.Server.V1.Class (AppT, State(..), runLogging)
+import           OpEnergy.Account.Server.V1.Class (profile, AppT, State(..), runLogging)
 import           OpEnergy.Account.Server.V1.Config
-import qualified OpEnergy.Account.Server.V1.Metrics as Metrics(MetricsState(..))
 import           Data.Text.Show
 
 -- | This function is being called when latest confirmed block had been discovered. You should expect, that it can be called by recieving notification from the blockspan service either at discover or at a time of connection of block time service to blockspan service. So it is expected, that it will run at each restart of the blockspan service or at reconnection to blockspan service or at blocktime service restart.
@@ -43,40 +41,37 @@ ensureFutureStrikeExistsAhead
      )
   => BlockHeader
   -> AppT m ()
-ensureFutureStrikeExistsAhead currentTip = do
+ensureFutureStrikeExistsAhead currentTip = profile "ensureFutureStrikeExistsAhead" $ do
   State{ config = Config
          { configBlockTimeFutureStrikeShouldExistsAheadCurrentTip = configBlockTimeFutureStrikeShouldExistsAheadCurrentTip
          , configBlockTimeStrikeFutureGuessMinimumBlockAheadCurrentTip = configBlockTimeStrikeFutureGuessMinimumBlockAheadCurrentTip
          }
        , accountDBPool = pool
-       , metrics = Metrics.MetricsState { Metrics.ensureFutureStrikeExistsAhead = ensureFutureStrikeExistsAhead
-                                        }
        } <- ask
-  P.observeDuration ensureFutureStrikeExistsAhead $ do
-    let minimumFutureStrikeHeight = blockHeaderHeight currentTip + naturalFromPositive configBlockTimeStrikeFutureGuessMinimumBlockAheadCurrentTip
-        maximumFutureStrikeHeight = blockHeaderHeight currentTip + naturalFromPositive configBlockTimeFutureStrikeShouldExistsAheadCurrentTip
-    runLogging $ $(logDebug) ("ensureFutureStrikeExistsAhead: currentTip: " <> tshow currentTip <>  ", min/max: " <> tshow [minimumFutureStrikeHeight, maximumFutureStrikeHeight])
-    nonExistentBlockHeights <- liftIO $ do
-      now <- getCurrentTime
-      flip runSqlPersistMPool pool $ do
-        futureStrikesE <- selectList
-          [ BlockTimeStrikeFutureBlock >=. minimumFutureStrikeHeight
-          , BlockTimeStrikeFutureBlock <=. maximumFutureStrikeHeight
-          ] []
-        let futureStrikes = List.map (\(Entity _ strike) -> blockTimeStrikeFutureBlock strike) futureStrikesE
-        let nonExistentStrikeHeights = List.filter
-              (\height-> height `notElem` futureStrikes)
-              [ minimumFutureStrikeHeight .. maximumFutureStrikeHeight ]
-        forM_ nonExistentStrikeHeights $ \height-> do
-          insert (BlockTimeStrikeFuture { blockTimeStrikeFutureBlock = height
-                                        , blockTimeStrikeFutureNlocktime =
-                                          fromIntegral
-                                          $ blockHeaderMediantime currentTip
-                                          + fromIntegral ((fromNatural (height - blockHeaderHeight currentTip)) * 600) -- assume 10 minutes time slices for nlocktime
-                                        , blockTimeStrikeFutureCreationTime = utcTimeToPOSIXSeconds now
-                                        })
+  let minimumFutureStrikeHeight = blockHeaderHeight currentTip + naturalFromPositive configBlockTimeStrikeFutureGuessMinimumBlockAheadCurrentTip
+      maximumFutureStrikeHeight = blockHeaderHeight currentTip + naturalFromPositive configBlockTimeFutureStrikeShouldExistsAheadCurrentTip
+  runLogging $ $(logDebug) ("ensureFutureStrikeExistsAhead: currentTip: " <> tshow currentTip <>  ", min/max: " <> tshow [minimumFutureStrikeHeight, maximumFutureStrikeHeight])
+  nonExistentBlockHeights <- liftIO $ do
+    now <- getCurrentTime
+    flip runSqlPersistMPool pool $ do
+      futureStrikesE <- selectList
+        [ BlockTimeStrikeFutureBlock >=. minimumFutureStrikeHeight
+        , BlockTimeStrikeFutureBlock <=. maximumFutureStrikeHeight
+        ] []
+      let futureStrikes = List.map (\(Entity _ strike) -> blockTimeStrikeFutureBlock strike) futureStrikesE
+      let nonExistentStrikeHeights = List.filter
+            (\height-> height `notElem` futureStrikes)
+            [ minimumFutureStrikeHeight .. maximumFutureStrikeHeight ]
+      forM_ nonExistentStrikeHeights $ \height-> do
+        insert (BlockTimeStrikeFuture { blockTimeStrikeFutureBlock = height
+                                      , blockTimeStrikeFutureNlocktime =
+                                        fromIntegral
+                                        $ blockHeaderMediantime currentTip
+                                        + fromIntegral ((fromNatural (height - blockHeaderHeight currentTip)) * 600) -- assume 10 minutes time slices for nlocktime
+                                      , blockTimeStrikeFutureCreationTime = utcTimeToPOSIXSeconds now
+                                      })
 
-        return nonExistentStrikeHeights
-    when (List.length nonExistentBlockHeights > 0) $ do
-      runLogging $ $(logInfo) ("ensureFutureStrikeExistsAhead: created future strikes: " <> (tshow nonExistentBlockHeights))
+      return nonExistentStrikeHeights
+  when (List.length nonExistentBlockHeights > 0) $ do
+    runLogging $ $(logInfo) ("ensureFutureStrikeExistsAhead: created future strikes: " <> (tshow nonExistentBlockHeights))
 


### PR DESCRIPTION
this PR:
1. removes old APIs, which haven't used paging result;
2. replaces request body provided AccountToken parameter with header provided parameter

currently, this branch had been deployed to the dev instance