### PR TITLE
improve load times for paging result api

### DIFF
--- a/oe-account-service/op-energy-account-api/src/Data/OpEnergy/Account/API/V1/BlockTimeStrike.hs
+++ b/oe-account-service/op-energy-account-api/src/Data/OpEnergy/Account/API/V1/BlockTimeStrike.hs
@@ -41,6 +41,7 @@ import           Data.Default
 import           Data.OpEnergy.API.V1.Block(BlockHeight, defaultBlockHeight)
 import           Data.OpEnergy.Account.API.V1.Account
 import           Data.OpEnergy.API.V1.Block(BlockHash)
+import           Data.OpEnergy.API.V1.Positive(Positive)
 import qualified Data.OpEnergy.API.V1.Hash as BlockHash (defaultHash)
 import           Data.OpEnergy.Account.API.V1.FilterRequest
 import           Data.OpEnergy.Account.API.V1.Common
@@ -75,6 +76,7 @@ data BlockTimeStrikeFilter = BlockTimeStrikeFilter
   , blockTimeStrikeFilterObservedBlockHashNEQ       :: Maybe BlockHash
   , blockTimeStrikeFilterSort                       :: Maybe SortOrder
   , blockTimeStrikeFilterClass                      :: Maybe BlockTimeStrikeFilterClass
+  , blockTimeStrikeFilterLinesPerPage               :: Maybe (Positive Int)
   }
   deriving (Eq, Show, Generic)
 instance ToSchema BlockTimeStrikeFilter where
@@ -106,6 +108,7 @@ defaultBlockTimeStrikeFilter = BlockTimeStrikeFilter
   , blockTimeStrikeFilterObservedBlockHashNEQ  = Just BlockHash.defaultHash
   , blockTimeStrikeFilterSort                  = Just Descend
   , blockTimeStrikeFilterClass                 = Just BlockTimeStrikeFilterClassGuessable
+  , blockTimeStrikeFilterLinesPerPage          = Just 100
   }
 
 defaultBlockTimeStrike :: BlockTimeStrike
@@ -215,6 +218,7 @@ instance BuildFilter BlockTimeStrike BlockTimeStrikeFilter where
                 mobservedBlockHashNEQ
                 _ -- sort
                 _ -- class
+                _ -- linesPerPage
               , _
               ) = List.concat
     [ maybe [] (\v-> [BlockTimeStrikeStrikeMediantime >=. v]) mstrikeMediantimeGTE

--- a/oe-account-service/op-energy-account-api/src/Data/OpEnergy/Account/API/V1/BlockTimeStrikeGuess.hs
+++ b/oe-account-service/op-energy-account-api/src/Data/OpEnergy/Account/API/V1/BlockTimeStrikeGuess.hs
@@ -43,6 +43,7 @@ import           Data.OpEnergy.Account.API.V1.UUID
 import           Data.OpEnergy.Account.API.V1.Common
 import           Data.OpEnergy.Account.API.V1.FilterRequest
 import           Data.OpEnergy.API.V1.Block(BlockHeight)
+import           Data.OpEnergy.API.V1.Positive(Positive)
 import           Data.OpEnergy.Account.API.V1.BlockTimeStrikeFilterClass
 
 share [mkPersist sqlSettings, mkMigrate "migrateBlockTimeStrikeGuess"] [persistLowerCase|
@@ -129,6 +130,7 @@ data BlockTimeStrikeGuessResultPublicFilter = BlockTimeStrikeGuessResultPublicFi
     -- sort
   , blockTimeStrikeGuessResultPublicFilterSort                  :: Maybe SortOrder
   , blockTimeStrikeGuessResultPublicFilterClass                 :: Maybe BlockTimeStrikeFilterClass
+  , blockTimeStrikeGuessResultPublicFilterLinesPerPage          :: Maybe (Positive Int)
   }
   deriving (Eq, Show, Generic)
 instance Default BlockTimeStrikeGuessResultPublicFilter where
@@ -189,6 +191,7 @@ instance BuildFilter BlockTimeStrikeGuess BlockTimeStrikeGuessResultPublicFilter
                 -- sort
                 _
                 _
+                _ -- lines per page
               , _
               ) = List.concat
     [ maybe [] (\v-> [BlockTimeStrikeGuessGuess ==. v]) mGuessEQ
@@ -218,6 +221,7 @@ instance BuildFilter Person BlockTimeStrikeGuessResultPublicFilter where
                 -- sort
                 _
                 _
+                _ -- lines per page
               , _
               ) = List.concat
     [ maybe [] (\v-> [ PersonUuid ==. v ]) mPersonEQ
@@ -248,6 +252,7 @@ instance BuildFilter BlockTimeStrike BlockTimeStrikeGuessResultPublicFilter wher
                 -- sort
                 _
                 _
+                _ -- lines per page
               , _
               ) = List.concat
         -- strike block height
@@ -282,4 +287,5 @@ defaultBlockTimeStrikeGuessResultPublicFilter =  BlockTimeStrikeGuessResultPubli
   , blockTimeStrikeGuessResultPublicFilterStrikeMediantimeNEQ   = Just 1
   , blockTimeStrikeGuessResultPublicFilterSort                  = Just Descend
   , blockTimeStrikeGuessResultPublicFilterClass                 = Just defaultBlockTimeStrikeFilterClass
+  , blockTimeStrikeGuessResultPublicFilterLinesPerPage          = Just 100
   }

--- a/oe-account-service/op-energy-account-api/src/Data/OpEnergy/Account/API/V1/PagingResult.hs
+++ b/oe-account-service/op-energy-account-api/src/Data/OpEnergy/Account/API/V1/PagingResult.hs
@@ -20,8 +20,6 @@ import           Data.Proxy
 data PagingResult a = PagingResult
   { pagingResultNextPage :: Maybe Word32
     -- ^ Nothing if there are no more pages coming
-  , pagingResultCount:: Word32
-    -- ^ records count. TOTAL, not count of elements of the page.
   , pagingResultResults :: [ a ]
     -- ^ contains list of records on a request page. Count of records defined by services' configs. For blocktime service, check configRecordsPerReply
   }
@@ -60,6 +58,5 @@ instance Default a => Default (PagingResult a) where
 defaultPagingResult :: Default a => PagingResult a
 defaultPagingResult = PagingResult
   { pagingResultNextPage = Nothing
-  , pagingResultCount = 1
   , pagingResultResults = [ def ]
   }

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeGuessService.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeGuessService.hs
@@ -139,22 +139,12 @@ getBlockTimeStrikeGuessResultsPage mpage mfilter = profile "getBlockTimeStrikeGu
       let
           page = maybe 0 id mpage
       recordsPerReply <- asks (configRecordsPerReply . config)
+      let
+          linesPerPage = maybe recordsPerReply (maybe recordsPerReply id . blockTimeStrikeGuessResultPublicFilterLinesPerPage . fst . unFilterRequest ) mfilter
       mret <- withDBNOTransactionROUnsafe "" $ do
-        count <- C.runConduit
-          $ filters recordsPerReply confirmedBlock
-          .| ( do
-                 let
-                     loop (acc::Int) = do
-                       mv <- C.await
-                       case mv of
-                         Nothing -> return acc
-                         Just _ -> do
-                           loop (acc + 1)
-                 loop 0
-             )
         res <- C.runConduit
-          $ filters recordsPerReply confirmedBlock
-          .| (C.drop (fromNatural page * fromPositive recordsPerReply) >> C.awaitForever C.yield) -- navigate to page
+          $ filters linesPerPage confirmedBlock
+          .| (C.drop (fromNatural page * fromPositive linesPerPage) >> C.awaitForever C.yield) -- navigate to page
           .| ( C.awaitForever $ \((Entity _ strike, Entity _ guess), Entity _ person) -> do
                C.yield $ BlockTimeStrikeGuessPublic
                          { person = personUuid person
@@ -163,20 +153,19 @@ getBlockTimeStrikeGuessResultsPage mpage mfilter = profile "getBlockTimeStrikeGu
                          , guess = blockTimeStrikeGuessGuess guess
                          }
              )
-          .| C.take (fromPositive recordsPerReply + 1) -- we take +1 to understand if there is a next page available
-        return (count, res)
+          .| C.take (fromPositive linesPerPage + 1) -- we take +1 to understand if there is a next page available
+        return (res)
       case mret of
           Nothing -> do
             throwJSON err500 ("something went wrong, check logs for details"::Text)
-          Just (count, guessesTail) -> do
+          Just (guessesTail) -> do
             let newPage =
-                  if List.length guessesTail > fromPositive recordsPerReply
+                  if List.length guessesTail > fromPositive linesPerPage
                   then Just (fromIntegral (fromNatural page + 1))
                   else Nothing
-                results = List.take (fromPositive recordsPerReply) guessesTail
+                results = List.take (fromPositive linesPerPage) guessesTail
             return $ PagingResult
               { pagingResultNextPage = newPage
-              , pagingResultCount = fromIntegral count
               , pagingResultResults = results
               }
   where
@@ -226,6 +215,8 @@ getBlockTimeStrikesGuessesPage mpage mfilter = profile "getBlockTimeStrikesGuess
   mlatestConfirmedBlock <- liftIO $ TVar.readTVarIO latestConfirmedBlockV
   averageBlockDiscoverSecs <- asks (configAverageBlockDiscoverSecs . config)
   minimumBlocksAhead <- asks (configBlockTimeStrikeMinimumBlockAheadCurrentTip . config)
+  let
+      linesPerPage = maybe recordsPerReply (maybe recordsPerReply id . blockTimeStrikeGuessResultPublicFilterLinesPerPage . fst . unFilterRequest ) mfilter
   case mlatestConfirmedBlock of
     Nothing -> do
       let msg = "getBlockTimeStrikesGuessesPage: no confirmed block found yet"
@@ -249,21 +240,9 @@ getBlockTimeStrikesGuessesPage mpage mfilter = profile "getBlockTimeStrikesGuess
                  :filter
                 )
       mret <- withDBNOTransactionROUnsafe "" $ do
-        count <- C.runConduit
-          $ filters finalFilter recordsPerReply
-          .| ( do
-                let
-                    loop (acc::Int) = do
-                      mv <- C.await
-                      case mv of
-                        Nothing -> return acc
-                        Just _-> do
-                          loop (acc + 1)
-                loop 0
-            )
         res <- C.runConduit
-          $ filters finalFilter recordsPerReply
-          .| (C.drop (fromNatural page * fromPositive recordsPerReply) >> C.awaitForever C.yield) -- navigate to page
+          $ filters finalFilter linesPerPage
+          .| (C.drop (fromNatural page * fromPositive linesPerPage) >> C.awaitForever C.yield) -- navigate to page
           .| ( C.awaitForever $ \((Entity _ strike, Entity _ guess), Entity _ person) -> do
               C.yield $ BlockTimeStrikeGuessPublic
                         { person = personUuid person
@@ -272,20 +251,19 @@ getBlockTimeStrikesGuessesPage mpage mfilter = profile "getBlockTimeStrikesGuess
                         , guess = blockTimeStrikeGuessGuess guess
                         }
             )
-          .| C.take (fromPositive recordsPerReply + 1) -- we take +1 to understand if there is a next page available
-        return (count, res)
+          .| C.take (fromPositive linesPerPage + 1) -- we take +1 to understand if there is a next page available
+        return (res)
       case mret of
           Nothing -> do
             throwJSON err500 ("something went wrong, check logs for details"::Text)
-          Just (count, guessesTail) -> do
+          Just (guessesTail) -> do
             let newPage =
-                  if List.length guessesTail > fromPositive recordsPerReply
+                  if List.length guessesTail > fromPositive linesPerPage
                   then Just (fromIntegral (fromNatural page + 1))
                   else Nothing
-                results = List.take (fromPositive recordsPerReply) guessesTail
+                results = List.take (fromPositive linesPerPage) guessesTail
             return $ PagingResult
               { pagingResultNextPage = newPage
-              , pagingResultCount = fromIntegral count
               , pagingResultResults = results
               }
   where
@@ -296,11 +274,11 @@ getBlockTimeStrikesGuessesPage mpage mfilter = profile "getBlockTimeStrikesGuess
       where
         id1 :: FilterRequest BlockTimeStrike BlockTimeStrikeGuessResultPublicFilter -> FilterRequest BlockTimeStrike BlockTimeStrikeGuessResultPublicFilter
         id1 = id -- helping typechecker
-    filters finalFilter recordsPerReply =
+    filters finalFilter linesPerPage =
       streamEntities
           finalFilter
           BlockTimeStrikeId
-          (PageSize ((fromPositive recordsPerReply) + 1))
+          (PageSize ((fromPositive linesPerPage) + 1))
           sort
           (Range Nothing Nothing)
       .| ( C.awaitForever $ \v@(Entity strikeId _)-> do
@@ -309,7 +287,7 @@ getBlockTimeStrikesGuessesPage mpage mfilter = profile "getBlockTimeStrikesGuess
             (streamEntities
               (( BlockTimeStrikeGuessStrike ==. strikeId ):(maybe [] (buildFilter . unFilterRequest . mapFilter) mfilter ))
               BlockTimeStrikeGuessId
-              (PageSize ((fromPositive recordsPerReply) + 1))
+              (PageSize ((fromPositive linesPerPage) + 1))
               sort
               (Range Nothing Nothing)
             )
@@ -320,7 +298,7 @@ getBlockTimeStrikesGuessesPage mpage mfilter = profile "getBlockTimeStrikesGuess
             ( streamEntities
               (( PersonId ==. blockTimeStrikeGuessPerson guess ):(maybe [] (buildFilter . unFilterRequest . mapFilter) mfilter ))
               PersonId
-              (PageSize ((fromPositive recordsPerReply) + 1))
+              (PageSize ((fromPositive linesPerPage) + 1))
               sort
               (Range Nothing Nothing)
             )
@@ -335,22 +313,12 @@ getBlockTimeStrikeGuessesPage
   -> AppM (PagingResult BlockTimeStrikeGuessPublic)
 getBlockTimeStrikeGuessesPage blockHeight strikeMediantime mpage mfilter = profile "getBlockTimeStrikesGuessesPage" $ do
   recordsPerReply <- asks (configRecordsPerReply . config)
+  let
+      linesPerPage = maybe recordsPerReply (maybe recordsPerReply id . blockTimeStrikeGuessResultPublicFilterLinesPerPage . fst . unFilterRequest ) mfilter
   mret <- withDBNOTransactionROUnsafe "" $ do
-    count <- C.runConduit
-      $ filters recordsPerReply
-      .| ( do
-             let
-                 loop (acc::Int) = do
-                   mv <- C.await
-                   case mv of
-                     Nothing -> return acc
-                     Just _-> do
-                       loop (acc + 1)
-             loop 0
-         )
     res <- C.runConduit
-      $ filters recordsPerReply
-      .| (C.drop (fromNatural page * fromPositive recordsPerReply) >> C.awaitForever C.yield) -- navigate to page
+      $ filters linesPerPage
+      .| (C.drop (fromNatural page * fromPositive linesPerPage) >> C.awaitForever C.yield) -- navigate to page
       .| ( C.awaitForever $ \((Entity _ strike, Entity _ guess), Entity _ person) -> do
            C.yield $ BlockTimeStrikeGuessPublic
                      { person = personUuid person
@@ -359,20 +327,19 @@ getBlockTimeStrikeGuessesPage blockHeight strikeMediantime mpage mfilter = profi
                      , guess = blockTimeStrikeGuessGuess guess
                      }
          )
-      .| C.take (fromPositive recordsPerReply + 1) -- we take +1 to understand if there is a next page available
-    return (count, res)
+      .| C.take (fromPositive linesPerPage + 1) -- we take +1 to understand if there is a next page available
+    return (res)
   case mret of
       Nothing -> do
         throwJSON err500 ("something went wrong, check logs for details"::Text)
-      Just (count, guessesTail) -> do
+      Just (guessesTail) -> do
         let newPage =
-              if List.length guessesTail > fromPositive recordsPerReply
+              if List.length guessesTail > fromPositive linesPerPage
               then Just (fromIntegral (fromNatural page + 1))
               else Nothing
-            results = List.take (fromPositive recordsPerReply) guessesTail
+            results = List.take (fromPositive linesPerPage) guessesTail
         return $ PagingResult
           { pagingResultNextPage = newPage
-          , pagingResultCount = fromIntegral count
           , pagingResultResults = results
           }
   where


### PR DESCRIPTION
This PR:
1. removes calculation of paging results total count. This way we don't spend time on fetching all pages to return 1 page;
2. introduce `linesPerPage` option for `filter` argument object, which defines how much lines should page contain;
3. refactor of the `/api/v1/blocks/guesses/page` call which data fetch flow was like: strikes-> guesses -> person, but now guesses-> strikes-> person as the answer will contain guesses at most, so no reason to fetch all the strikes in this case.