### PR TITLE
provide internal api to create scheduled sttrike creation

### DIFF
--- a/oe-account-service/op-energy-account-api/src/Data/OpEnergy/Account/API.hs
+++ b/oe-account-service/op-energy-account-api/src/Data/OpEnergy/Account/API.hs
@@ -54,6 +54,7 @@ type API
   :<|> AccountAPI
   :<|> BlockTimeSwaggerAPI
   :<|> BlockTimeAPI
+  :<|> "api" :> "v1" :> "blocktime" :> "internal" :> InternalBlockTimeSwaggerAPI -- serve swagger internal API with public API
 
 -- | Combined internal API
 type InternalSwaggerBlockTimeAPI

--- a/oe-account-service/op-energy-account-api/src/Data/OpEnergy/Account/API.hs
+++ b/oe-account-service/op-energy-account-api/src/Data/OpEnergy/Account/API.hs
@@ -20,6 +20,9 @@ accountAPI = Proxy
 blockTimeAPI :: Proxy BlockTimeAPI
 blockTimeAPI = Proxy
 
+internalBlockTimeAPI :: Proxy InternalBlockTimeAPI
+internalBlockTimeAPI = Proxy
+
 accountBlockTimeAPI :: Proxy AccountBlockTimeAPI
 accountBlockTimeAPI = Proxy
 
@@ -28,6 +31,9 @@ type AccountAPI
 
 type BlockTimeAPI
   = "api" :> "v1" :> "blocktime" :> BlockTimeV1API {- V1 API -}
+
+type InternalBlockTimeAPI
+  = "api" :> "v1" :> "blocktime" :> InternalBlockTimeV1API {- V1 API -}
 
 -- | Composition of Account and Blocktime APIs
 type AccountBlockTimeAPI
@@ -39,12 +45,20 @@ type AccountSwaggerAPI
 type BlockTimeSwaggerAPI
   = "api" :> "v1" :> "blocktime" :> "swagger.json" :> Get '[JSON] Swagger
 
+type InternalBlockTimeSwaggerAPI
+  = "api" :> "v1" :> "blocktime" :> "swagger.json" :> Get '[JSON] Swagger
+
 -- | Combined API of a Account, BlockTime services with Swagger documentation.
 type API
   = AccountSwaggerAPI
   :<|> AccountAPI
   :<|> BlockTimeSwaggerAPI
   :<|> BlockTimeAPI
+
+-- | Combined internal API
+type InternalSwaggerBlockTimeAPI
+  =    InternalBlockTimeSwaggerAPI
+  :<|> InternalBlockTimeAPI
 
 -- | Swagger spec for Todo API.
 accountApiSwagger :: Swagger
@@ -57,6 +71,13 @@ accountApiSwagger = toSwagger accountAPI
 blockTimeApiSwagger :: Swagger
 blockTimeApiSwagger = toSwagger blockTimeAPI
   & info.title   .~ "OpEnergy BlockTime API"
+  & info.version .~ "1.0"
+  & info.description ?~ "OpEnergy"
+  & info.license ?~ ("MIT" & url ?~ URL "http://mit.com")
+
+internalBlockTimeApiSwagger :: Swagger
+internalBlockTimeApiSwagger = toSwagger internalBlockTimeAPI
+  & info.title   .~ "OpEnergy Internal BlockTime API"
   & info.version .~ "1.0"
   & info.description ?~ "OpEnergy"
   & info.license ?~ ("MIT" & url ?~ URL "http://mit.com")

--- a/oe-account-service/op-energy-account-api/src/Data/OpEnergy/Account/API/V1/Common.hs
+++ b/oe-account-service/op-energy-account-api/src/Data/OpEnergy/Account/API/V1/Common.hs
@@ -34,9 +34,9 @@ jsonCommonOptions singleton = defaultOptions
       (\s -> case s of
           [] -> []
           (first:rest)-> (Char.toLower first):rest
-      ) . (List.drop $ List.length $ List.takeWhile (not . Char.isSpace) $ show singleton)
+      ) . (List.drop $ List.length $ List.takeWhile (Char.isAlphaNum) $ show singleton)
     , constructorTagModifier = \v ->
-      case (List.drop $ List.length $ List.takeWhile (not . Char.isSpace) $ show singleton) v of
+      case (List.drop $ List.length $ List.takeWhile (Char.isAlphaNum) $ show singleton) v of
         [] -> List.map Char.toLower v
         (first:rest)-> (Char.toLower first):rest
     }

--- a/oe-account-service/op-energy-account-service/app/Main.hs
+++ b/oe-account-service/op-energy-account-service/app/Main.hs
@@ -44,6 +44,9 @@ main = withSocketsDo {- needed for websocket client -} $ runStdoutLoggingT $ do
   blockTimeStrikeWebsocketClientA <- liftIO $ asyncBound $ runAppT state $ do -- this thread is for serving HTTP/websockets requests
     runLogging $ $(logInfo) "block time strike websocket client API"
     BlockTimeStrike.runBlockSpanClient
+  internalServerA <- liftIO $ asyncBound $ runAppT state $ do -- this thread is for serving HTTP/websockets requests
+    runLogging $ $(logInfo) "serving internal API"
+    BlockTimeStrike.runInternalServer
   serverA <- liftIO $ asyncBound $ runAppT state $ do -- this thread is for serving HTTP/websockets requests
     runLogging $ $(logInfo) "serving API"
     runServer
@@ -52,6 +55,7 @@ main = withSocketsDo {- needed for websocket client -} $ runStdoutLoggingT $ do
     BlockTimeStrike.newTipHandlerLoop
   liftIO $ waitAnyCancel $ -- waits for any of threads to shutdown in order to shutdown the rest
     [ serverA
+    , internalServerA
     , schedulerA
     , prometheusA
     , schedulerBlockTimeStrikeA

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/Account/Server.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/Account/Server.hs
@@ -74,6 +74,7 @@ runServer = do
           :<|> OpEnergy.Account.Server.V1.accountServer
           :<|> (return blockTimeApiSwagger)
           :<|> OpEnergy.BlockTimeStrike.Server.V1.blockTimeServer
+          :<|> (return internalBlockTimeApiSwagger) -- serve swagger for internal block time API
 
 -- | tasks, that should be running during start
 bootstrapTasks :: (MonadLoggerIO m, MonadMonitor m) => State -> m ()

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/Account/Server/V1/Config.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/Account/Server/V1/Config.hs
@@ -67,6 +67,8 @@ data Config = Config
     -- ^ defines how much records should be returned in one page
   , configAverageBlockDiscoverSecs :: Positive Int
     -- ^ defines how much seconds takes to discover in average
+  , configInternalHTTPAPIPort :: Positive Int
+    -- ^ defines port for internal API, which is not supposed to be public
   }
   deriving Show
 instance FromJSON Config where
@@ -91,6 +93,7 @@ instance FromJSON Config where
     <*> ( v .:? "BLOCKTIME_STRIKE_SHOULD_EXISTS_AHEAD_CURRENT_TIP" .!= (configBlockTimeStrikeShouldExistsAheadCurrentTip defaultConfig))
     <*> ( v .:? "BLOCKTIME_RECORDS_PER_REPLY" .!= (configRecordsPerReply defaultConfig))
     <*> ( v .:? "AVERAGE_BLOCK_DISCOVER_SECS" .!= (configAverageBlockDiscoverSecs defaultConfig))
+    <*> ( v .:? "INTERNAL_HTTP_API_PORT" .!= (configInternalHTTPAPIPort defaultConfig))
 
 -- need to get Key from json, which represented as base64-encoded string
 instance FromJSON Key where
@@ -122,6 +125,7 @@ defaultConfig = Config
   , configBlockTimeStrikeShouldExistsAheadCurrentTip = 12
   , configRecordsPerReply = 100
   , configAverageBlockDiscoverSecs = 600
+  , configInternalHTTPAPIPort = 8900
   }
 
 getConfigFromEnvironment :: IO Config

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server.hs
@@ -14,6 +14,7 @@ module OpEnergy.BlockTimeStrike.Server
   , schedulerMainLoop
   , OpEnergy.BlockTimeStrike.Server.V1.runBlockSpanClient
   , OpEnergy.BlockTimeStrike.Server.V1.newTipHandlerLoop
+  , runInternalServer
   ) where
 
 import           System.IO as IO
@@ -23,10 +24,13 @@ import           Control.Monad.IO.Class(liftIO, MonadIO)
 import           Control.Monad.Logger (MonadLoggerIO, logDebug )
 
 import           Prometheus(MonadMonitor)
+import           Servant ( Application, Proxy(..), ServerT, serve, hoistServer, (:<|>)(..))
+import           Network.Wai.Handler.Warp(run)
 
+import           Data.OpEnergy.Account.API
 import           Data.OpEnergy.API.V1.Positive
 import           OpEnergy.Account.Server.V1.Config
-import           OpEnergy.Account.Server.V1.Class (AppT, State(..), runAppT, runLogging)
+import           OpEnergy.Account.Server.V1.Class (AppM, AppT, State(..), runAppT, runLogging)
 import           OpEnergy.BlockTimeStrike.Server.V1
 
 
@@ -45,3 +49,20 @@ schedulerMainLoop = do
   OpEnergy.BlockTimeStrike.Server.V1.schedulerIteration
   liftIO $ threadDelay ((fromPositive delaySecs) * 1000000)
   schedulerMainLoop
+
+-- | Runs HTTP server on a port defined in config in the State datatype
+runInternalServer :: (MonadIO m) => AppT m ()
+runInternalServer = do
+  s <- ask
+  let port = fromPositive $ configInternalHTTPAPIPort (config s)
+  liftIO $ run port (app s)
+  where
+    app :: State-> Application
+    app s = serve api $ hoistServer api (runAppT s) serverSwaggerBackend
+      where
+        api :: Proxy InternalSwaggerBlockTimeAPI
+        api = Proxy
+        -- | Combined server of a OpEnergy service with Swagger documentation.
+        serverSwaggerBackend :: ServerT InternalSwaggerBlockTimeAPI AppM
+        serverSwaggerBackend = (return internalBlockTimeApiSwagger)
+          :<|> OpEnergy.BlockTimeStrike.Server.V1.internalBlockTimeServer

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1.hs
@@ -12,6 +12,7 @@
 {-# LANGUAGE DuplicateRecordFields      #-}
 module OpEnergy.BlockTimeStrike.Server.V1
   ( blockTimeServer
+  , internalBlockTimeServer
   , schedulerIteration
   , runBlockSpanClient
   , OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeService.newTipHandlerLoop
@@ -116,3 +117,8 @@ runBlockSpanClient = do
             TVar.writeTVar latestConfirmedBlockV (Just header) -- blocktime and guesses create handlers will need this info
             TVar.writeTVar latestUnconfirmedBlockHeightV (Just unconfirmedBlockHeight)
           MVar.putMVar blockTimeStrikeConfirmedTipV header -- this way we will notify handler about new confirmed tip
+
+internalBlockTimeServer :: ServerT InternalBlockTimeV1API (AppT Handler)
+internalBlockTimeServer = getCurrentTips
+  :<|> createBlockTimeStrikeUnauth
+


### PR DESCRIPTION
This PR introduces internal API, which is should not be publicly available as it provides a way to create strikes without authorization.

API documentation is available as a subsection of `/api/v1/blocktime/internal/{internal_api_endpoints}`, API itself is intended to be used as follows `curl http://localhost:$INTERNAL_API_PORT/{internal_api_endpoints}`, where `INTERNAL_API_PORT` = 8900 by default. This had been made for a purpose of accessing API documentation.