### PR TITLE
return person UUID from login and register API calls

### DIFF
--- a/oe-account-service/op-energy-account-api/op-energy-account-api.cabal
+++ b/oe-account-service/op-energy-account-api/op-energy-account-api.cabal
@@ -55,6 +55,7 @@ library
                    , Data.OpEnergy.Account.API.V1.PagingResult
                    , Data.OpEnergy.Account.API.V1.FilterRequest
                    , Data.OpEnergy.Account.API.V1.Common
+                   , Data.OpEnergy.Account.API.V2
 
     build-depends:    base ^>=4.15.1.0
                     , aeson

--- a/oe-account-service/op-energy-account-api/src/Data/OpEnergy/Account/API.hs
+++ b/oe-account-service/op-energy-account-api/src/Data/OpEnergy/Account/API.hs
@@ -13,6 +13,7 @@ import           Servant.API
 import           Servant.Swagger
 
 import           Data.OpEnergy.Account.API.V1
+import           Data.OpEnergy.Account.API.V2
 
 accountAPI :: Proxy AccountAPI
 accountAPI = Proxy
@@ -24,7 +25,9 @@ accountBlockTimeAPI :: Proxy AccountBlockTimeAPI
 accountBlockTimeAPI = Proxy
 
 type AccountAPI
-  = "api" :> "v1" :> "account" :> AccountV1API {- V1 API -}
+  = "api" :> ( "v1" :> "account" :> AccountV1API {- V1 API -}
+             :<|> "v2" :> "account" :> AccountV2API {- V2 API -}
+             )
 
 type BlockTimeAPI
   = "api" :> "v1" :> "blocktime" :> BlockTimeV1API {- V1 API -}

--- a/oe-account-service/op-energy-account-api/src/Data/OpEnergy/Account/API/V1.hs
+++ b/oe-account-service/op-energy-account-api/src/Data/OpEnergy/Account/API/V1.hs
@@ -128,11 +128,12 @@ type FakeWSAPI = Get '[JSON] ()
 data RegisterResult = RegisterResult
   { accountSecret :: AccountSecret
   , accountToken  :: AccountToken
+  , personUUID :: UUID Person
   }
   deriving (Show, Generic, Typeable)
 
 defaultRegisterResult :: RegisterResult
-defaultRegisterResult = RegisterResult defaultAccountSecret defaultAccountToken
+defaultRegisterResult = RegisterResult defaultAccountSecret defaultAccountToken defaultUUID
 
 instance ToJSON RegisterResult
 instance FromJSON RegisterResult

--- a/oe-account-service/op-energy-account-api/src/Data/OpEnergy/Account/API/V1/UUID.hs
+++ b/oe-account-service/op-energy-account-api/src/Data/OpEnergy/Account/API/V1/UUID.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE OverloadedLists            #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
@@ -37,8 +38,11 @@ instance FromJSON (UUID a) where
 instance Show a => ToSchema (UUID a) where
   declareNamedSchema proxy = genericDeclareNamedSchema defaultSchemaOptions proxy
     & mapped.schema.description ?~ (T.unlines
-      [ "This is the example of the UUID"
+      [ "UUID is an unique id of some resource"
       ])
+    & mapped.schema.type_ ?~ SwaggerString
+    & mapped.schema.properties .~ []
+    & mapped.schema.required .~ []
     & mapped.schema.example ?~ toJSON defaultUUID
 instance ToSchema ShortByteString where
   declareNamedSchema _ = declareNamedSchema (Proxy :: Proxy Text)

--- a/oe-account-service/op-energy-account-api/src/Data/OpEnergy/Account/API/V2.hs
+++ b/oe-account-service/op-energy-account-api/src/Data/OpEnergy/Account/API/V2.hs
@@ -25,7 +25,7 @@ import           Data.OpEnergy.Account.API.V1.UUID
 type AccountV2API
   = "login"
     :> ReqBody '[JSON] AccountSecret
-    :> Description "Performs login with given account secret. Returns AccountToken value for being used with the rest API calls. See 'register' API call description for the reference of expected frontend's behavior related to secrets and tokens"
+    :> Description "Performs login with given account secret. Returns LoginResult(token and person UUID) value for being used with the rest API calls. See 'register' API call description for the reference of expected frontend's behavior related to secrets and tokens"
     :> Post '[JSON] LoginResult
 
 data LoginResult = LoginResult

--- a/oe-account-service/op-energy-account-api/src/Data/OpEnergy/Account/API/V2.hs
+++ b/oe-account-service/op-energy-account-api/src/Data/OpEnergy/Account/API/V2.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE TypeOperators              #-}
+{-# LANGUAGE DeriveDataTypeable         #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE EmptyDataDecls             #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE DuplicateRecordFields      #-}
+module Data.OpEnergy.Account.API.V2 where
+
+import           Data.Swagger
+import           Control.Lens
+import           GHC.Generics
+import           Data.Typeable              (Typeable)
+import           Data.Aeson
+
+import           Servant.API
+
+import           Data.OpEnergy.Account.API.V1.Account
+import           Data.OpEnergy.Account.API.V1.UUID
+
+-- | API specifications of a backend service for Swagger
+type AccountV2API
+  = "login"
+    :> ReqBody '[JSON] AccountSecret
+    :> Description "Performs login with given account secret. Returns AccountToken value for being used with the rest API calls. See 'register' API call description for the reference of expected frontend's behavior related to secrets and tokens"
+    :> Post '[JSON] LoginResult
+
+data LoginResult = LoginResult
+  { accountToken  :: AccountToken
+  , personUUID :: UUID Person
+  }
+  deriving (Show, Generic, Typeable)
+
+defaultLoginResult :: LoginResult
+defaultLoginResult = LoginResult defaultAccountToken defaultUUID
+
+instance ToJSON LoginResult
+instance FromJSON LoginResult
+instance ToSchema LoginResult where
+  declareNamedSchema proxy = genericDeclareNamedSchema defaultSchemaOptions proxy
+    & mapped.schema.description ?~ "LoginResult schema"
+    & mapped.schema.example ?~ toJSON defaultLoginResult
+
+

--- a/oe-account-service/op-energy-account-service/op-energy-account-service.cabal
+++ b/oe-account-service/op-energy-account-service/op-energy-account-service.cabal
@@ -64,6 +64,8 @@ library
                    , OpEnergy.BlockTimeStrike.Server.V1.BlockTimeScheduledStrikeCreation
                    , Data.Text.Show
                    , OpEnergy.PagingResult
+                   , OpEnergy.Account.Server.V2
+                   , OpEnergy.Account.Server.V2.AccountService
     build-depends:    base ^>=4.15.1.0
                     , aeson
                     , aeson-pretty

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/Account/Server.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/Account/Server.hs
@@ -33,6 +33,8 @@ import           OpEnergy.Account.Server.V1.Class (AppT, AppM, State(..), defaul
 import           OpEnergy.Account.Server.V1.DB
 import           OpEnergy.Account.Server.V1.Metrics
 
+import           OpEnergy.Account.Server.V2
+
 -- required by prometheus-client
 instance MonadMonitor (LoggingT IO)
 instance MonadMonitor (NoLoggingT IO)
@@ -71,7 +73,9 @@ runServer = do
         -- | Combined server of a OpEnergy service with Swagger documentation.
         serverSwaggerBackend :: ServerT API AppM
         serverSwaggerBackend = (return accountApiSwagger)
-          :<|> OpEnergy.Account.Server.V1.accountServer
+          :<|> ( OpEnergy.Account.Server.V1.accountServer
+               :<|> OpEnergy.Account.Server.V2.accountServer
+               )
           :<|> (return blockTimeApiSwagger)
           :<|> OpEnergy.BlockTimeStrike.Server.V1.blockTimeServer
 

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/Account/Server/V1/AccountService.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/Account/Server/V1/AccountService.hs
@@ -17,6 +17,7 @@ module OpEnergy.Account.Server.V1.AccountService
   , postDisplayName
   , loadDBState
   , mgetPersonByAccountToken -- supposed that another services will use this function to authenticate user
+  , mgetPersonByHashedSecret
   ) where
 
 import           Servant (err400)
@@ -86,6 +87,7 @@ register = do
     return $! RegisterResult
       { accountSecret = secret
       , accountToken = verifyAccountToken $! Text.decodeUtf8 token
+      , personUUID = uuid
       }
 
 -- | see OpEnergy.Account.API.V1.AccountV1API for reference of 'login' API call

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/Account/Server/V2.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/Account/Server/V2.hs
@@ -1,0 +1,28 @@
+{-- |
+ - This module is the top module of backend V1
+ -}
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DeriveDataTypeable         #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE TypeOperators              #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TemplateHaskell            #-}
+{-# LANGUAGE DuplicateRecordFields      #-}
+module OpEnergy.Account.Server.V2
+  ( accountServer
+  )where
+
+import           Servant
+
+import           Data.OpEnergy.Account.API.V2
+import           OpEnergy.Account.Server.V1.Class (AppT)
+import           OpEnergy.Account.Server.V2.AccountService
+
+-- | this is the implementation of OpEnergy.Account.API.V1.AccountV1API. Check this type for the reference and API
+-- documentation
+accountServer :: ServerT AccountV2API (AppT Handler)
+accountServer
+  = OpEnergy.Account.Server.V2.AccountService.login
+

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/Account/Server/V2/AccountService.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/Account/Server/V2/AccountService.hs
@@ -29,7 +29,7 @@ import           Data.OpEnergy.API.V1.Error
 import           OpEnergy.Account.Server.V1.AccountService(mgetPersonByHashedSecret)
 
 
--- | see OpEnergy.Account.API.V2.AccountV1API for reference of 'login' API call
+-- | see OpEnergy.Account.API.V2.AccountV2API for reference of 'login' API call
 -- 3 * O(ln n)
 login :: AccountSecret -> AppM LoginResult
 login secret = do

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/Account/Server/V2/AccountService.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/Account/Server/V2/AccountService.hs
@@ -1,0 +1,72 @@
+{-- | This module implements Account service in terms of OpEnergy.Account.API.V1.AccountV1API API, which you may
+ - be insteresting to check for API description.
+ -
+ - Implementation details are defined in op-energy/README.md
+ -
+ - TODO: we may consider:
+ - 1. using some random value of say [ 0; 10000] as default value for loginsCount instead of 0;
+ - 2. increasing loginsCount not by 1, but by random value [1;10000].
+ - This way we can increase an entropy in case of worries of lacking of randomness in token. This will reduce the time
+ - to overflow the loginsCount accumulator, but it is expected to happen at some point anyway...
+ -}
+{-# LANGUAGE TemplateHaskell          #-}
+{-# LANGUAGE OverloadedStrings          #-}
+module OpEnergy.Account.Server.V2.AccountService
+  ( login
+  ) where
+
+import           Servant (err400)
+import           Control.Monad.Trans.Reader (ask)
+import           Control.Monad.IO.Class (liftIO)
+import           Control.Monad.Logger(logError)
+import qualified Data.Text.Encoding as Text
+import qualified Data.ByteString.Lazy as LBS
+
+import qualified Data.Aeson as Aeson
+import qualified Web.ClientSession as ClientSession
+import           Database.Persist.Postgresql
+import qualified Prometheus as P
+
+
+import           Data.OpEnergy.Account.API.V2
+import           Data.OpEnergy.Account.API.V1.Hash
+import           Data.OpEnergy.Account.API.V1.Account
+import           OpEnergy.Account.Server.V1.Config
+import           OpEnergy.Account.Server.V1.Class ( AppM, State(..), runLogging)
+import           OpEnergy.Account.Server.V1.Metrics(MetricsState(..))
+import           Data.OpEnergy.API.V1.Error
+import           OpEnergy.Account.Server.V1.AccountService(mgetPersonByHashedSecret)
+
+
+-- | see OpEnergy.Account.API.V2.AccountV1API for reference of 'login' API call
+-- 3 * O(ln n)
+login :: AccountSecret -> AppM LoginResult
+login secret = do
+  State{ config = Config { configSalt = configSalt
+                         , configAccountTokenEncryptionPrivateKey = configAccountTokenEncryptionPrivateKey
+                         }
+       , accountDBPool = pool
+       , metrics = MetricsState { accountLogin = accountLogin
+                                , accountTokenEncrypt = accountTokenEncrypt
+                                , accountUpdateLoginsCount = accountUpdateLoginsCount
+                                }
+       } <- ask
+  P.observeDuration accountLogin $ do
+    let hashedSecret = hashSBS configSalt unAccountSecret secret
+    mperson <- mgetPersonByHashedSecret hashedSecret
+    case mperson of
+      Nothing -> do
+        let err = "ERROR: login: failed to find user account with given secret"
+        runLogging $ $(logError) err
+        throwJSON err400 err
+      Just (Entity personKey person) -> do
+        -- increase loginsCount returning new value
+        loginsCount <- liftIO $! P.observeDuration accountUpdateLoginsCount $ flip runSqlPersistMPool pool $ do
+          update personKey [ PersonLoginsCount =. (personLoginsCount person + 1) ]
+          return (personLoginsCount person + 1)
+        token <- liftIO $ P.observeDuration accountTokenEncrypt $! ClientSession.encryptIO configAccountTokenEncryptionPrivateKey $! LBS.toStrict $! Aeson.encode (personUuid person, loginsCount)
+        return $! LoginResult
+          { accountToken = verifyAccountToken $! Text.decodeUtf8 token
+          , personUUID = personUuid person
+          }
+

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/Account/Server/V2/AccountService.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/Account/Server/V2/AccountService.hs
@@ -1,13 +1,4 @@
-{-- | This module implements Account service in terms of OpEnergy.Account.API.V1.AccountV1API API, which you may
- - be insteresting to check for API description.
- -
- - Implementation details are defined in op-energy/README.md
- -
- - TODO: we may consider:
- - 1. using some random value of say [ 0; 10000] as default value for loginsCount instead of 0;
- - 2. increasing loginsCount not by 1, but by random value [1;10000].
- - This way we can increase an entropy in case of worries of lacking of randomness in token. This will reduce the time
- - to overflow the loginsCount accumulator, but it is expected to happen at some point anyway...
+{-- | This module implements Account service in terms of OpEnergy.Account.API.V2.AccountV2API API
  -}
 {-# LANGUAGE TemplateHaskell          #-}
 {-# LANGUAGE OverloadedStrings          #-}


### PR DESCRIPTION
This PR:
1. adds /api/v2/account/login with return LoginResult with token and uuid;
2. add personUUID field into response of the /api/v1/account/register;

the /v2/ prefix is just because to keep compatibility of older frontends with API return type change.