### PR TITLE
fix: route /api/v2/account to the account service

### DIFF
--- a/oe-account-service/op-energy-account-service/module-backend.nix
+++ b/oe-account-service/op-energy-account-service/module-backend.nix
@@ -83,6 +83,10 @@ in
       enable = true;
       virtualHosts.op-energy = {
         extraConfig = ''
+          location /api/v2/account {
+                  limit_req zone=api burst=10 nodelay;
+                  proxy_pass http://127.0.0.1:${toString cfg.api_port}/api/v2/account;
+          }
           location /api/v1/account {
                   limit_req zone=api burst=10 nodelay;
                   proxy_pass http://127.0.0.1:${toString cfg.api_port}/api/v1/account;


### PR DESCRIPTION
This PR fixes API route for /v2/account prefix to pass it to the account service correctly