### PR TITLE
refactor: simplify strike on the next epoch block

### DIFF
--- a/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeScheduledStrikeCreation.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeScheduledStrikeCreation.hs
@@ -133,7 +133,7 @@ ensureNextEpochGuessableStrikeExists confirmedTip = profile "ensureNextEpochGues
     Just Nothing -> let
         doNothingAsNextEpochBlockTimeStrikeExists = return ()
       in doNothingAsNextEpochBlockTimeStrikeExists
-    Just (Just _) -> let
+    Just (Just _newBlockTimeStrikeCreated) -> let
         logNewestCreatedBlockTimeStrike = do
           runLogging $ $(logInfo) $ "ensureNextEpochGuessableStrikeExists: created strike ("
             <> tshow nextEpochStartBlockHeight <> " / "


### PR DESCRIPTION
This PR contains refactoring of the strike for the next epoch block creation routine in order to simplify calculation of the mediantime of the strike.