### PR TITLE
fix /api/v1/blocktime/strikes/page API call to respect mediantime within  filter

### DIFF
--- a/oe-account-service/op-energy-account-service/op-energy-account-service.cabal
+++ b/oe-account-service/op-energy-account-service/op-energy-account-service.cabal
@@ -68,6 +68,7 @@ library
                    , OpEnergy.BlockTimeStrike.Server.V1.Context
                    , OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeObserve
                    , Data.Text.Show
+                   , Data.Conduit.Extra.Zip
                    , OpEnergy.Error
                    , OpEnergy.PagingResult
                    , OpEnergy.ExceptMaybe

--- a/oe-account-service/op-energy-account-service/op-energy-account-service.cabal
+++ b/oe-account-service/op-energy-account-service/op-energy-account-service.cabal
@@ -68,7 +68,9 @@ library
                    , OpEnergy.BlockTimeStrike.Server.V1.Context
                    , OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeObserve
                    , Data.Text.Show
+                   , OpEnergy.Error
                    , OpEnergy.PagingResult
+                   , OpEnergy.ExceptMaybe
                    , OpEnergy.Account.Server.V2
                    , OpEnergy.Account.Server.V2.AccountService
     build-depends:    base ^>=4.15.1.0

--- a/oe-account-service/op-energy-account-service/op-energy-account-service.cabal
+++ b/oe-account-service/op-energy-account-service/op-energy-account-service.cabal
@@ -73,6 +73,7 @@ library
                    , OpEnergy.ExceptMaybe
                    , OpEnergy.Account.Server.V2
                    , OpEnergy.Account.Server.V2.AccountService
+                   , OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeFilter
     build-depends:    base ^>=4.15.1.0
                     , aeson
                     , aeson-pretty

--- a/oe-account-service/op-energy-account-service/src/Data/Conduit/Extra/Zip.hs
+++ b/oe-account-service/op-energy-account-service/src/Data/Conduit/Extra/Zip.hs
@@ -7,10 +7,7 @@ import qualified Data.Conduit as C
 import qualified Data.Conduit.Combinators as C
 import qualified Data.Conduit.Internal as C(zipSources)
 
--- | this combinator repeatedly zips the @value0@ gotten from the stream (by the combinator)
--- with a values gotten from the nested conduit, dependently on the @value0@
--- until the nested conduit won't stop producing values. Then, combinator awaits
--- for the next value for @value0@ and reiterate with it
+-- | Given a function @f@, this @zipConcatMapMC f@ transforms a sequence @a_0, a_1, ...@ by zipping each @a_i@ with the values yielded by @f a_i@.
 zipConcatMapMC
   :: Monad m
   => (a -> ConduitT () b m ())

--- a/oe-account-service/op-energy-account-service/src/Data/Conduit/Extra/Zip.hs
+++ b/oe-account-service/op-energy-account-service/src/Data/Conduit/Extra/Zip.hs
@@ -1,0 +1,21 @@
+module Data.Conduit.Extra.Zip
+  ( zipConcatMapMC
+  ) where
+
+import           Data.Conduit (ConduitT)
+import qualified Data.Conduit as C
+import qualified Data.Conduit.Combinators as C
+import qualified Data.Conduit.Internal as C(zipSources)
+
+-- | this combinator repeatedly zips the @value0@ gotten from the stream (by the combinator)
+-- with a values gotten from the nested conduit, dependently on the @value0@
+-- until the nested conduit won't stop producing values. Then, combinator awaits
+-- for the next value for @value0@ and reiterate with it
+zipConcatMapMC
+  :: Monad m
+  => (a -> ConduitT () b m ())
+  -> ConduitT a (a, b) m ()
+zipConcatMapMC nested = C.awaitForever $ \v-> do
+    C.toProducer $ C.zipSources
+      (C.repeat v)
+      (nested v)

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeFilter.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeFilter.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE FlexibleContexts  #-}
+module OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeFilter
+  ( buildFilter
+  ) where
+
+
+import           Database.Persist
+
+
+import           Data.OpEnergy.API.V1.Block
+import           Data.OpEnergy.API.V1.Positive( naturalFromPositive, Positive)
+import           Data.OpEnergy.Account.API.V1.BlockTimeStrike
+import           Data.OpEnergy.Account.API.V1.BlockTimeStrikeFilterClass
+
+
+-- | this function builds a strike filter with given dynamic variables like
+-- current latest confirmed and unconfirmed blocks and a like
+buildFilter
+  :: [Filter BlockTimeStrike]
+  -> Maybe BlockTimeStrikeFilterClass
+  -> BlockHeight
+  -> BlockHeader
+  -> Positive Int
+  -> [Filter BlockTimeStrike]
+buildFilter
+    strikeFilter
+    filterClass
+    latestUnconfirmedBlockHeight
+    latestConfirmedBlock
+    configBlockTimeStrikeGuessMinimumBlockAheadCurrentTip =
+  case filterClass of
+    Nothing -> strikeFilter
+    Just BlockTimeStrikeFilterClassGuessable ->
+      let
+          minimumGuessableBlock = latestUnconfirmedBlockHeight + naturalFromPositive configBlockTimeStrikeGuessMinimumBlockAheadCurrentTip
+          minimumGuessableMediantime
+            = fromIntegral (blockHeaderMediantime latestConfirmedBlock)
+            + 600
+              * (naturalFromPositive configBlockTimeStrikeGuessMinimumBlockAheadCurrentTip
+                + (latestUnconfirmedBlockHeight - blockHeaderHeight latestConfirmedBlock)
+                )
+          isStrikeBlockHeightGuessable
+            = BlockTimeStrikeBlock >=. minimumGuessableBlock
+          isStrikeMediantimeGuessable
+            = BlockTimeStrikeStrikeMediantime
+              >. fromIntegral minimumGuessableMediantime
+      in
+        ( isStrikeBlockHeightGuessable
+        : isStrikeMediantimeGuessable
+        : strikeFilter
+        )
+    Just BlockTimeStrikeFilterClassOutcomeKnown ->
+      let
+          strikeOutcomeKnownByBlockHeight
+            = BlockTimeStrikeBlock <=. blockHeaderHeight latestConfirmedBlock
+          strikeOutcomeKnownByMediantime
+            = BlockTimeStrikeStrikeMediantime <=. fromIntegral (blockHeaderMediantime latestConfirmedBlock)
+      in
+        ( [strikeOutcomeKnownByBlockHeight] ||. [strikeOutcomeKnownByMediantime]
+        ) ++ strikeFilter
+    Just BlockTimeStrikeFilterClassOutcomeUnknown ->
+      let
+          strikeBlockHeightUnconfirmed
+            = BlockTimeStrikeBlock >. blockHeaderHeight latestConfirmedBlock
+          strikeMediantimeInFuture
+            = BlockTimeStrikeStrikeMediantime >. fromIntegral (blockHeaderMediantime latestConfirmedBlock)
+      in
+      ( strikeBlockHeightUnconfirmed
+      : strikeMediantimeInFuture
+      : strikeFilter
+      )

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeFilter.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeFilter.hs
@@ -14,7 +14,7 @@ import           Data.OpEnergy.Account.API.V1.BlockTimeStrikeFilterClass
 
 
 -- | this function builds a strike filter with given dynamic variables like
--- current latest confirmed and unconfirmed blocks and a like
+-- current latest confirmed and unconfirmed blocks and etc
 buildFilter
   :: [Filter BlockTimeStrike]
   -> Maybe BlockTimeStrikeFilterClass

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeGuessService.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeGuessService.hs
@@ -278,10 +278,10 @@ getBlockTimeStrikesGuessesPage mpage mfilter = profile "getBlockTimeStrikesGuess
     $ runExceptT $ do
       (latestUnconfirmedBlockHeight, latestConfirmedBlock) <- ExceptT
         $ liftIO $ STM.atomically $ runExceptT $ (,)
-          <$> (exceptTMaybeT "latest unconfirmed block haven't been received yet"
+          <$> (exceptTMaybeT "latest unconfirmed block hasn't been received yet"
               $ TVar.readTVar latestUnconfirmedBlockHeightV
               )
-          <*> ( exceptTMaybeT "latest confirmed block haven't been received yet"
+          <*> ( exceptTMaybeT "latest confirmed block hasn't been received yet"
               $ TVar.readTVar latestConfirmedBlockV
               )
       let
@@ -332,9 +332,9 @@ getBlockTimeStrikesGuessesPage mpage mfilter = profile "getBlockTimeStrikesGuess
                 mObserved <- lift $ selectFirst [ BlockTimeStrikeObservedStrike ==. strikeId ][]
                 C.yield (guess, strikeE, mObserved) -- don't care about existence of observed data
               Just BlockTimeStrikeFilterClassGuessable-> do
-                C.yield (guess, strikeE, Nothing) -- strike have not been observed and finalFilter should ensure, that it is in the future with proper guess threshold
+                C.yield (guess, strikeE, Nothing) -- strike has not been observed and finalFilter should ensure, that it is in the future with proper guess threshold
               Just BlockTimeStrikeFilterClassOutcomeUnknown-> do
-                C.yield (guess, strikeE, Nothing) -- haven't been observed
+                C.yield (guess, strikeE, Nothing) -- hasn't been observed
               Just BlockTimeStrikeFilterClassOutcomeKnown-> do
                 mObserved <- lift $ selectFirst [ BlockTimeStrikeObservedStrike ==. strikeId ][]
                 C.yield (guess, strikeE, mObserved) -- had been observed

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeGuessService.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeGuessService.hs
@@ -177,33 +177,33 @@ getBlockTimeStrikeGuessResultsPage mpage mfilter = profile "getBlockTimeStrikeGu
         res <- C.runConduit
           $ filters linesPerPage confirmedBlock
           .| (C.drop (fromNatural page * fromPositive linesPerPage) >> C.awaitForever C.yield) -- navigate to page
-          .| ( C.awaitForever $ \(Entity _ strike, Entity _ guess, Entity _ person, mObserved) -> do
-               C.yield $ BlockTimeStrikeGuessResultPublic
-                         { person = personUuid person
-                         , strike = BlockTimeStrikePublic
-                           { blockTimeStrikePublicObservedResult = maybe
-                             Nothing
-                             (\(Entity _ result) -> Just (blockTimeStrikeObservedIsFast result))
-                             mObserved
-                           , blockTimeStrikePublicObservedBlockMediantime = maybe
-                             Nothing
-                             (\(Entity _ result) -> Just (blockTimeStrikeObservedJudgementBlockMediantime result))
-                             mObserved
-                           , blockTimeStrikePublicObservedBlockHash = maybe
-                             Nothing
-                             (\(Entity _ result) -> Just (blockTimeStrikeObservedJudgementBlockHash result))
-                             mObserved
-                           , blockTimeStrikePublicObservedBlockHeight = maybe
-                             Nothing
-                             (\(Entity _ result) -> Just (blockTimeStrikeObservedJudgementBlockHeight result))
-                             mObserved
-                           , blockTimeStrikePublicBlock = blockTimeStrikeBlock strike
-                           , blockTimeStrikePublicStrikeMediantime = blockTimeStrikeStrikeMediantime strike
-                           , blockTimeStrikePublicCreationTime = blockTimeStrikeCreationTime strike
-                           }
-                         , creationTime = blockTimeStrikeGuessCreationTime guess
-                         , guess = blockTimeStrikeGuessIsFast guess
-                         }
+          .| ( C.map $ \(Entity _ strike, Entity _ guess, Entity _ person, mObserved) ->
+               BlockTimeStrikeGuessResultPublic
+                 { person = personUuid person
+                 , strike = BlockTimeStrikePublic
+                   { blockTimeStrikePublicObservedResult = maybe
+                     Nothing
+                     (\(Entity _ result) -> Just (blockTimeStrikeObservedIsFast result))
+                     mObserved
+                   , blockTimeStrikePublicObservedBlockMediantime = maybe
+                     Nothing
+                     (\(Entity _ result) -> Just (blockTimeStrikeObservedJudgementBlockMediantime result))
+                     mObserved
+                   , blockTimeStrikePublicObservedBlockHash = maybe
+                     Nothing
+                     (\(Entity _ result) -> Just (blockTimeStrikeObservedJudgementBlockHash result))
+                     mObserved
+                   , blockTimeStrikePublicObservedBlockHeight = maybe
+                     Nothing
+                     (\(Entity _ result) -> Just (blockTimeStrikeObservedJudgementBlockHeight result))
+                     mObserved
+                   , blockTimeStrikePublicBlock = blockTimeStrikeBlock strike
+                   , blockTimeStrikePublicStrikeMediantime = blockTimeStrikeStrikeMediantime strike
+                   , blockTimeStrikePublicCreationTime = blockTimeStrikeCreationTime strike
+                   }
+                 , creationTime = blockTimeStrikeGuessCreationTime guess
+                 , guess = blockTimeStrikeGuessIsFast guess
+                 }
              )
           .| C.take (fromPositive linesPerPage + 1) -- we take +1 to understand if there is a next page available
         return (res)
@@ -389,8 +389,8 @@ getBlockTimeStrikesGuessesPage mpage mfilter = profile "getBlockTimeStrikesGuess
           (ReaderT SqlBackend (NoLoggingT (ResourceT IO)))
           ()
         buildBlockTimeStrikeGuessResultPublic =
-          C.awaitForever $ \((Entity _ guess, Entity _ strike, mObserved), Entity _ person) -> do
-            C.yield $ BlockTimeStrikeGuessResultPublic
+          C.map $ \((Entity _ guess, Entity _ strike, mObserved), Entity _ person) ->
+            BlockTimeStrikeGuessResultPublic
               { person = personUuid person
               , strike = BlockTimeStrikePublic
                 { blockTimeStrikePublicObservedResult = maybe
@@ -433,33 +433,33 @@ getBlockTimeStrikeGuessesPage blockHeight strikeMediantime mpage mfilter = profi
     res <- C.runConduit
       $ filters linesPerPage
       .| (C.drop (fromNatural page * fromPositive linesPerPage) >> C.awaitForever C.yield) -- navigate to page
-      .| ( C.awaitForever $ \(Entity _ strike, Entity _ guess, Entity _ person, mObserved) -> do
-           C.yield $ BlockTimeStrikeGuessResultPublic
-                     { person = personUuid person
-                     , strike = BlockTimeStrikePublic
-                       { blockTimeStrikePublicObservedResult = maybe
-                         Nothing
-                         (\(Entity _ result)-> Just (blockTimeStrikeObservedIsFast result))
-                         mObserved
-                       , blockTimeStrikePublicObservedBlockMediantime = maybe
-                         Nothing
-                         (\(Entity _ result)-> Just (blockTimeStrikeObservedJudgementBlockMediantime result))
-                         mObserved
-                       , blockTimeStrikePublicObservedBlockHash = maybe
-                         Nothing
-                         (\(Entity _ result)-> Just (blockTimeStrikeObservedJudgementBlockHash result))
-                         mObserved
-                       , blockTimeStrikePublicObservedBlockHeight = maybe
-                         Nothing
-                         (\(Entity _ result)-> Just (blockTimeStrikeObservedJudgementBlockHeight result))
-                         mObserved
-                       , blockTimeStrikePublicBlock = blockTimeStrikeBlock strike
-                       , blockTimeStrikePublicStrikeMediantime = blockTimeStrikeStrikeMediantime strike
-                       , blockTimeStrikePublicCreationTime = blockTimeStrikeCreationTime strike
-                       }
-                     , creationTime = blockTimeStrikeGuessCreationTime guess
-                     , guess = blockTimeStrikeGuessIsFast guess
-                     }
+      .| ( C.map $ \(Entity _ strike, Entity _ guess, Entity _ person, mObserved) ->
+           BlockTimeStrikeGuessResultPublic
+             { person = personUuid person
+             , strike = BlockTimeStrikePublic
+               { blockTimeStrikePublicObservedResult = maybe
+                 Nothing
+                 (\(Entity _ result)-> Just (blockTimeStrikeObservedIsFast result))
+                 mObserved
+               , blockTimeStrikePublicObservedBlockMediantime = maybe
+                 Nothing
+                 (\(Entity _ result)-> Just (blockTimeStrikeObservedJudgementBlockMediantime result))
+                 mObserved
+               , blockTimeStrikePublicObservedBlockHash = maybe
+                 Nothing
+                 (\(Entity _ result)-> Just (blockTimeStrikeObservedJudgementBlockHash result))
+                 mObserved
+               , blockTimeStrikePublicObservedBlockHeight = maybe
+                 Nothing
+                 (\(Entity _ result)-> Just (blockTimeStrikeObservedJudgementBlockHeight result))
+                 mObserved
+               , blockTimeStrikePublicBlock = blockTimeStrikeBlock strike
+               , blockTimeStrikePublicStrikeMediantime = blockTimeStrikeStrikeMediantime strike
+               , blockTimeStrikePublicCreationTime = blockTimeStrikeCreationTime strike
+               }
+             , creationTime = blockTimeStrikeGuessCreationTime guess
+             , guess = blockTimeStrikeGuessIsFast guess
+             }
          )
       .| C.take (fromPositive linesPerPage + 1) -- we take +1 to understand if there is a next page available
     return (res)

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeGuessService.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeGuessService.hs
@@ -819,10 +819,10 @@ getBlockTimeStrikeGuessPerson uuid blockHeight strikeMediantime = profile "getBl
          , Maybe (Entity BlockTimeStrikeObserved)
          )
     maybeFetchBlockTimeStrikeObserved (strikeE@(Entity strikeId _), guessE) = do
-               mObserved <- selectFirst
-                 [ BlockTimeStrikeObservedStrike ==. strikeId]
-                 []
-               return (strikeE, guessE, mObserved)
+      mObserved <- selectFirst
+        [ BlockTimeStrikeObservedStrike ==. strikeId]
+        []
+      return (strikeE, guessE, mObserved)
     renderBlockTimeStrikeGuessResultPublic
       :: Person
       -> ( Entity BlockTimeStrike

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeGuessService.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeGuessService.hs
@@ -259,13 +259,14 @@ getBlockTimeStrikesGuessesPage mpage mfilter = profile "getBlockTimeStrikesGuess
               $ TVar.readTVar latestConfirmedBlockV
               )
       let
-          finalStrikesFilter = BlockTimeStrikeFilter.buildFilter
-            strikeFilter
-            (maybe Nothing (blockTimeStrikeGuessResultPublicFilterClass . fst . unFilterRequest) mfilter)
-            latestUnconfirmedBlockHeight
-            latestConfirmedBlock
-            configBlockTimeStrikeGuessMinimumBlockAheadCurrentTip
-      exceptTMaybeT ("db query failed")
+          finalStrikesFilter =
+            BlockTimeStrikeFilter.buildFilterByClass
+              (maybe Nothing (blockTimeStrikeGuessResultPublicFilterClass . fst . unFilterRequest) mfilter)
+              latestUnconfirmedBlockHeight
+              latestConfirmedBlock
+              configBlockTimeStrikeGuessMinimumBlockAheadCurrentTip
+            ++ strikeFilter
+      exceptTMaybeT "db query failed"
         $ pagingResult
           mpage
           linesPerPage

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeGuessService.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeGuessService.hs
@@ -15,7 +15,7 @@ module OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeGuessService
   ) where
 
 import           Servant (err400, err500)
-import           Control.Monad.Trans.Reader (asks)
+import           Control.Monad.Trans.Reader (asks, ReaderT(..))
 import           Control.Monad.Logger( logError, NoLoggingT)
 import           Data.Time.Clock(getCurrentTime)
 import           Data.Time.Clock.POSIX(utcTimeToPOSIXSeconds)
@@ -24,7 +24,6 @@ import qualified Control.Concurrent.STM.TVar as TVar
 import           Control.Monad(void)
 import qualified Data.List as List
 import           Data.Text(Text)
-import           Control.Monad.Trans.Reader( ReaderT(..))
 import           Control.Monad.Trans.Resource( ResourceT)
 import           Control.Monad.Trans.Except( runExceptT, ExceptT(..))
 

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeObserve.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeObserve.hs
@@ -34,7 +34,6 @@ import           OpEnergy.Account.Server.V1.Config (Config(..))
 import           OpEnergy.Account.Server.V1.Class ( AppT
                                                   , State(..)
                                                   , profile
-                                                  , withDBNOTransactionROUnsafe
                                                   , withDBTransaction
                                                   , runLoggingIO
                                                   , runLogging
@@ -180,7 +179,7 @@ withLeastUnobservedConfirmedBlock
   -> AppT m ()
 withLeastUnobservedConfirmedBlock mpersistedBlockHeightC payload = do
   mlatestConfirmedHeight <- runMaybeT $ do
-    mret <- MaybeT $ withDBNOTransactionROUnsafe "" $ runMaybeT $ do
+    mret <- MaybeT $ withDBTransaction "" $ runMaybeT $ do
       Entity _ record <- MaybeT $ selectFirst [][]
       MaybeT $ return $ blockTimeStrikeDBLatestConfirmedHeight record
     MaybeT $ return mret

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeService.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeService.hs
@@ -155,12 +155,15 @@ getBlockTimeStrikesPage mpage mfilter = profile "getBlockTimeStrikesPage" $ do
           <*> (exceptTMaybeT "latest confirmed block hasn't been received yet"
               $ TVar.readTVar latestConfirmedBlockV
               )
-      let strikeFilter = BlockTimeStrikeFilter.buildFilter
-            (maybe [] (buildFilter . unFilterRequest . mapFilter) mfilter)
-            (maybe Nothing (blockTimeStrikeFilterClass . fst . unFilterRequest) mfilter)
-            latestUnconfirmedBlockHeight
-            latestConfirmedBlock
-            configBlockTimeStrikeGuessMinimumBlockAheadCurrentTip
+      let
+          staticPartFilter =  (maybe [] (buildFilter . unFilterRequest . mapFilter) mfilter)
+          strikeFilter =
+            BlockTimeStrikeFilter.buildFilterByClass
+              (maybe Nothing (blockTimeStrikeFilterClass . fst . unFilterRequest) mfilter)
+              latestUnconfirmedBlockHeight
+              latestConfirmedBlock
+              configBlockTimeStrikeGuessMinimumBlockAheadCurrentTip
+            ++ staticPartFilter
       exceptTMaybeT "getBlockTimeStrikePast failed"
         $ getBlockTimeStrikePast strikeFilter
   where

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeService.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeService.hs
@@ -12,8 +12,8 @@ module OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeService
   , getBlockTimeStrike
   ) where
 
-import           Servant (err400, err500)
-import           Control.Monad.Trans.Reader ( ask, asks)
+import           Servant (err400, err500, Handler)
+import           Control.Monad.Trans.Reader ( ask, asks, ReaderT)
 import           Control.Monad.Logger( logError, logInfo)
 import           Control.Monad(forever, when)
 import           Data.Time.Clock(getCurrentTime)
@@ -163,6 +163,12 @@ getBlockTimeStrikesPage mpage mfilter = profile "getBlockTimeStrikesPage" $ do
         $ getBlockTimeStrikePast strikeFilter
   where
     sort = maybe Descend (sortOrder . unFilterRequest) mfilter
+    getBlockTimeStrikePast
+      :: [Filter BlockTimeStrike]
+      -> ReaderT
+         State
+         Handler
+         (Maybe (PagingResult BlockTimeStrikeWithGuessesCountPublic))
     getBlockTimeStrikePast strikeFilter = do
       recordsPerReply <- asks (configRecordsPerReply . config)
       let

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeService.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeService.hs
@@ -141,10 +141,10 @@ getBlockTimeStrikesPage mpage mfilter = profile "getBlockTimeStrikesPage" $ do
     $ runExceptT $ do
       (latestUnconfirmedBlockHeight, latestConfirmedBlock) <-
         ExceptT $ liftIO $ STM.atomically $ runExceptT $ (,)
-          <$> (exceptTMaybeT "latest unconfirmed block haven't been received yet"
+          <$> (exceptTMaybeT "latest unconfirmed block hasn't been received yet"
               $ TVar.readTVar latestUnconfirmedBlockHeightV
               )
-          <*> (exceptTMaybeT "latest confirmed block haven't been received yet"
+          <*> (exceptTMaybeT "latest confirmed block hasn't been received yet"
               $ TVar.readTVar latestConfirmedBlockV
               )
       let strikeFilter = BlockTimeStrikeFilter.buildFilter
@@ -180,9 +180,9 @@ getBlockTimeStrikesPage mpage mfilter = profile "getBlockTimeStrikesPage" $ do
                     []
                   C.yield (v, mObserved) -- don't care about existence of observed data
                 Just BlockTimeStrikeFilterClassGuessable->
-                  C.yield (v, Nothing) -- strike have not been observed and strikeFilter should ensure, that it is in the future with proper guess threshold
+                  C.yield (v, Nothing) -- strike has not been observed and strikeFilter should ensure, that it is in the future with proper guess threshold
                 Just BlockTimeStrikeFilterClassOutcomeUnknown-> do
-                  C.yield (v, Nothing) -- haven't been observed
+                  C.yield (v, Nothing) -- hasn't been observed
                 Just BlockTimeStrikeFilterClassOutcomeKnown-> do
                   -- now get possible observed data for strike
                   mObserved <- lift $ selectFirst

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeService.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeService.hs
@@ -331,7 +331,7 @@ getBlockTimeStrikesPage mpage mfilter = profile "getBlockTimeStrikesPage" $ do
                  ]
         Just BlockTimeStrikeFilterClassOutcomeKnown-> do
           -- now get possible observed data for strike
-          shouldNotBeNothing <- selectFirst
+          observedStrikeExpectedToExist <- selectFirst
             ( (BlockTimeStrikeObservedStrike ==. strikeId)
             : (maybe [] ( buildFilter
                         . unFilterRequest
@@ -340,11 +340,11 @@ getBlockTimeStrikesPage mpage mfilter = profile "getBlockTimeStrikesPage" $ do
               )
             )
             []
-          case shouldNotBeNothing of
+          case observedStrikeExpectedToExist of
             Nothing -> return []
             Just _ -> return
               [( strikeE
-               , shouldNotBeNothing
+               , observedStrikeExpectedToExist
                , mguessesCount
                ) -- had been observed
               ]

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/Error.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/Error.hs
@@ -11,11 +11,11 @@ import           Control.Monad.Error.Class(MonadError)
 import           Servant(ServerError)
 import           Data.OpEnergy.API.V1.Error(throwJSON)
 
--- | the goal of this function is to wrap the 'payload' with exception handling
--- For this, payload should return value of type Either l r: In case if payload
--- will return 'Left reason', this function will call 'handler reason' and will
--- throw JSON exception with 'throwJSON' function
--- In case of 'Right result' it will just return the result
+-- | The goal of this function is to turn failure results from @payload@ into JSON  `ServerError`s.
+-- For this, @payload@ should return value of type @Either l r@: In the case that @payload@
+-- returns @Left reason@, this function will call @handler reason@ and will
+-- throw a JSON exception with 'throwJSON' function
+-- In the case of 'Right result' it will just return the result.
 eitherThrowJSON
   :: ( Monad m
      , MonadError ServerError m

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/Error.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/Error.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+module OpEnergy.Error
+  ( eitherThrowJSON
+  ) where
+
+import           Data.Text(Text)
+import           Data.Aeson (ToJSON)
+import           Control.Monad.Error.Class(MonadError)
+
+import           Servant(ServerError)
+import           Data.OpEnergy.API.V1.Error(throwJSON)
+
+-- | the goal of this function is to wrap the 'payload' with exception handling
+-- For this, payload should return value of type Either l r: In case if payload
+-- will return 'Left reason', this function will call 'handler reason' and will
+-- throw JSON exception with 'throwJSON' function
+-- In case of 'Right result' it will just return the result
+eitherThrowJSON
+  :: ( Monad m
+     , MonadError ServerError m
+     , ToJSON l
+     )
+  => (l -> m (ServerError, Text))
+  -> m (Either l r)
+  -> m r
+eitherThrowJSON handler payload = do
+  eret <- payload
+  case eret of
+    Right ret -> return ret
+    Left reason -> do
+      (err, msg) <- handler reason
+      throwJSON err msg
+
+

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/ExceptMaybe.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/ExceptMaybe.hs
@@ -1,0 +1,20 @@
+module OpEnergy.ExceptMaybe
+  ( exceptTMaybeT
+  ) where
+
+import           Control.Monad.Trans.Except(ExceptT(..))
+
+-- | this function wraps function, which returns value of type 'Maybe result'
+-- into ExceptT transformer by providing 'Left' value in case of function will
+-- return Nothing. The case 'Just result' will be mapped to 'Right result'
+exceptTMaybeT
+  :: Monad m
+  => l
+  -> m (Maybe r)
+  -> ExceptT l m r
+exceptTMaybeT left f = ExceptT $ do
+  v <- f
+  case v of
+    Nothing -> return (Left left)
+    Just some -> return (Right some)
+

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/PagingResult.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/PagingResult.hs
@@ -50,7 +50,7 @@ pagingResult mpage recordsPerReply filter sortOrder field next = profile "paging
     pageResults <- runConduit
       $ loopSource Nothing
       .| next
-      .| (C.drop (fromNatural page * fromPositive recordsPerReply) >> C.awaitForever C.yield) -- navigate to page
+      .| skipToNeededPage -- navigate to page
       .| C.take (fromPositive recordsPerReply + 1) -- we take +1 to understand if there is a next page available
     return (pageResults)
   case mret of
@@ -66,6 +66,7 @@ pagingResult mpage recordsPerReply filter sortOrder field next = profile "paging
         , pagingResultResults = results
         }
   where
+    skipToNeededPage = (C.drop (fromNatural page * fromPositive recordsPerReply) >> C.awaitForever C.yield)
     page = maybe 0 id mpage
     loopSource moffset = do
       let


### PR DESCRIPTION
This PR fixes /api/v1/blocktime/strikes/page call which previously had not respected the case when strike had been observed by mediantime

Also, this PR includes refactoring of the conduit transformers by naming them and providing types, which should make them more readable