### PR TITLE
37 apiv1blocktimestrikespage is missing observedresult

### DIFF
--- a/oe-account-service/op-energy-account-api/src/Data/OpEnergy/Account/API/V1/BlockTimeStrike.hs
+++ b/oe-account-service/op-energy-account-api/src/Data/OpEnergy/Account/API/V1/BlockTimeStrike.hs
@@ -88,6 +88,8 @@ data BlockTimeStrikeFilter = BlockTimeStrikeFilter
   , blockTimeStrikeFilterStrikeBlockHeightNEQ       :: Maybe BlockHeight
   , blockTimeStrikeFilterObservedBlockHashEQ        :: Maybe BlockHash
   , blockTimeStrikeFilterObservedBlockHashNEQ       :: Maybe BlockHash
+  , blockTimeStrikeFilterObservedResultEQ           :: Maybe SlowFast
+  , blockTimeStrikeFilterObservedResultNEQ          :: Maybe SlowFast
   , blockTimeStrikeFilterSort                       :: Maybe StrikeSortOrder
   , blockTimeStrikeFilterClass                      :: Maybe BlockTimeStrikeFilterClass
   , blockTimeStrikeFilterLinesPerPage               :: Maybe (Positive Int)
@@ -120,6 +122,8 @@ defaultBlockTimeStrikeFilter = BlockTimeStrikeFilter
   , blockTimeStrikeFilterStrikeBlockHeightNEQ  = Just 1
   , blockTimeStrikeFilterObservedBlockHashEQ   = Just BlockHash.defaultHash
   , blockTimeStrikeFilterObservedBlockHashNEQ  = Just BlockHash.defaultHash
+  , blockTimeStrikeFilterObservedResultEQ      = Just Slow
+  , blockTimeStrikeFilterObservedResultNEQ     = Just Fast
   , blockTimeStrikeFilterSort                  = Just StrikeSortOrderDescend
   , blockTimeStrikeFilterClass                 = Just BlockTimeStrikeFilterClassGuessable
   , blockTimeStrikeFilterLinesPerPage          = Just 100
@@ -270,6 +274,8 @@ instance BuildFilter BlockTimeStrike BlockTimeStrikeFilter where
                 mstrikeBlockHeightNEQ
                 _  -- mobservedBlockHashEQ
                 _  -- mobservedBlockHashNEQ
+                _  -- mobservedResultEQ
+                _  -- mobservedResultNEQ
                 _ -- sort
                 _ -- class
                 _ -- linesPerPage
@@ -297,6 +303,8 @@ instance BuildFilter BlockTimeStrikeObserved BlockTimeStrikeFilter where
                 _
                 mobservedBlockHashEQ
                 mobservedBlockHashNEQ
+                mobservedResultEQ
+                mobservedResultNEQ
                 _ -- sort
                 _ -- class
                 _ -- linesPerPage
@@ -304,6 +312,8 @@ instance BuildFilter BlockTimeStrikeObserved BlockTimeStrikeFilter where
               ) = List.concat
     [ maybe [] (\v-> [BlockTimeStrikeObservedJudgementBlockHash ==. v]) mobservedBlockHashEQ
     , maybe [] (\v-> [BlockTimeStrikeObservedJudgementBlockHash !=. v]) mobservedBlockHashNEQ
+    , maybe [] (\v-> [BlockTimeStrikeObservedIsFast ==. v]) mobservedResultEQ
+    , maybe [] (\v-> [BlockTimeStrikeObservedIsFast !=. v]) mobservedResultNEQ
     ]
 
 -- | we need to use separate sort order as we can sort strikes by guesses count

--- a/oe-account-service/op-energy-account-api/src/Data/OpEnergy/Account/API/V1/BlockTimeStrike.hs
+++ b/oe-account-service/op-energy-account-api/src/Data/OpEnergy/Account/API/V1/BlockTimeStrike.hs
@@ -235,7 +235,7 @@ defaultSlowFast = Slow
 verifySlowFast :: Text-> SlowFast
 verifySlowFast "slow" = Slow
 verifySlowFast "fast" = Fast
-verifySlowFast _ = error "verifySlowFast: wrong value"
+verifySlowFast v = error ("verifySlowFast: wrong value: " ++ Text.unpack v)
 
 instance ToParamSchema BlockTimeStrikeFilter where
   toParamSchema v = mempty

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/PagingResult.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/PagingResult.hs
@@ -53,8 +53,8 @@ pagingResult mpage recordsPerReply filter sortOrder field next = profile "paging
         (PageSize ((fromPositive recordsPerReply) + 1))
         sortOrder
         (Range Nothing Nothing)
-      .| (C.drop (fromNatural page * fromPositive recordsPerReply) >> C.awaitForever C.yield) -- navigate to page
       .| next
+      .| (C.drop (fromNatural page * fromPositive recordsPerReply) >> C.awaitForever C.yield) -- navigate to page
       .| C.take (fromPositive recordsPerReply + 1) -- we take +1 to understand if there is a next page available
     return (pageResults)
   case mret of
@@ -71,3 +71,4 @@ pagingResult mpage recordsPerReply filter sortOrder field next = profile "paging
         }
   where
     page = maybe 0 id mpage
+


### PR DESCRIPTION
This PR introduces 'observedResultEQ' and 'observedResultNEQ' filter options to the /api/v1/blocktime/strikes/page API call.
It replaces streamEntities from 'persistent-pagination' library with custom implementation.
I wanted to dig into the source of issue of why streamEntities stopped working as expected earlier, but it without merging this PR it seems, that there will be other newcoming branches be deployed to the dev instance, which will break frontend's expectation.

So looks like we need to merge this PR and create another issue for investigation

This PR had already been running on dev instance