### PR TITLE
PART2: Remove result suffix from types and split handlers

### DIFF
--- a/oe-account-service/op-energy-account-api/src/Data/OpEnergy/Account/API/V1.hs
+++ b/oe-account-service/op-energy-account-api/src/Data/OpEnergy/Account/API/V1.hs
@@ -22,8 +22,7 @@ import           Data.OpEnergy.API.V1.Natural
 import           Data.OpEnergy.Account.API.V1.Account
 import           Data.OpEnergy.Account.API.V1.BlockTimeStrikeGuess
                    ( BlockTimeStrikeGuess
-                   , BlockTimeStrikeGuessResult
-                   , BlockTimeStrikeGuessResultFilter
+                   , BlockTimeStrikeGuessFilter
                    )
 import           Data.OpEnergy.Account.API.V1.SlowFast
                    ( SlowFast
@@ -159,12 +158,12 @@ type BlockTimeV1API
        "filter"
        ( FilterRequest
            BlockTimeStrikeGuess
-           BlockTimeStrikeGuessResultFilter
+           BlockTimeStrikeGuessFilter
        )
     :> Description "returns guesses for the given blocktime strike. By \
                    \default, results are order by id in decending order \
                    \(from new to old)"
-    :> Get '[JSON] (PagingResult BlockTimeStrikeGuessResult)
+    :> Get '[JSON] (PagingResult BlockTimeStrikeGuess)
 
   :<|> "strike"
     :> "guesses"
@@ -193,12 +192,12 @@ type BlockTimeV1API
        "filter"
        ( FilterRequest
          BlockTimeStrikeGuess
-         BlockTimeStrikeGuessResultFilter
+         BlockTimeStrikeGuessFilter
        )
     :> Description "returns guesses for the given blocktime strike. By \
                    \default, results are order by id in decending order (from \
                    \new to old)"
-    :> Get '[JSON] (PagingResult BlockTimeStrikeGuessResult)
+    :> Get '[JSON] (PagingResult BlockTimeStrikeGuess)
 
   :<|> "strike"
     :> Capture "BlockHeight" BlockHeight
@@ -218,7 +217,7 @@ type BlockTimeV1API
     :> Capture "BlockHeight" BlockHeight
     :> Capture "StrikeMediantime" (Natural Int)
     :> Description "returns user's guess for the given blocktime strike."
-    :> Get '[JSON] BlockTimeStrikeGuessResult
+    :> Get '[JSON] BlockTimeStrikeGuess
 
   :<|> "strike"
     :> "guess"
@@ -227,7 +226,7 @@ type BlockTimeV1API
     :> Capture "BlockHeight" BlockHeight
     :> Capture "StrikeMediantime" (Natural Int)
     :> Description "returns user's guess for the given blocktime strike."
-    :> Get '[JSON] BlockTimeStrikeGuessResult
+    :> Get '[JSON] BlockTimeStrikeGuess
 
   :<|> "git-hash"
     :> Description "returns short hash of commit of the op-energy git repo that had been used to build backend"

--- a/oe-account-service/op-energy-account-api/src/Data/OpEnergy/Account/API/V1/BlockTimeStrikeGuess.hs
+++ b/oe-account-service/op-energy-account-api/src/Data/OpEnergy/Account/API/V1/BlockTimeStrikeGuess.hs
@@ -10,8 +10,7 @@
 {-# LANGUAGE DerivingStrategies         #-}
 module Data.OpEnergy.Account.API.V1.BlockTimeStrikeGuess
   ( BlockTimeStrikeGuess(..)
-  , BlockTimeStrikeGuessResult(..)
-  , BlockTimeStrikeGuessResultFilter(..)
+  , BlockTimeStrikeGuessFilter(..)
   ) where
 
 import           Data.Swagger
@@ -69,75 +68,47 @@ defaultBlockTimeStrikeGuess = BlockTimeStrikeGuess
   , guess = def
   }
 
-data BlockTimeStrikeGuessResult = BlockTimeStrikeGuessResult
-  { person :: UUID Person
-  , strike :: BlockTimeStrike
-  , creationTime :: POSIXTime
-  , guess :: SlowFast
-  }
-  deriving (Show, Generic)
-instance ToJSON BlockTimeStrikeGuessResult
-instance ToSchema BlockTimeStrikeGuessResult where
-  declareNamedSchema proxy = genericDeclareNamedSchema defaultSchemaOptions proxy
-    & mapped.schema.type_ ?~ SwaggerObject
-    & mapped.schema.example ?~ toJSON defaultBlockTimeStrikeGuessResult
-    & mapped.schema.required .~
-      [ "person"
-      , "strike"
-      , "creationTime"
-      , "guess"
-      ]
-instance Default BlockTimeStrikeGuessResult where
-  def = defaultBlockTimeStrikeGuessResult
-defaultBlockTimeStrikeGuessResult :: BlockTimeStrikeGuessResult
-defaultBlockTimeStrikeGuessResult = BlockTimeStrikeGuessResult
-  { person = defaultUUID
-  , strike = def
-  , creationTime = defaultPOSIXTime
-  , guess = def
-  }
-
-data BlockTimeStrikeGuessResultFilter = BlockTimeStrikeGuessResultFilter
+data BlockTimeStrikeGuessFilter = BlockTimeStrikeGuessFilter
     -- person
-  { blockTimeStrikeGuessResultFilterPersonEQ              :: Maybe (UUID Person)
-  , blockTimeStrikeGuessResultFilterPersonNEQ             :: Maybe (UUID Person)
+  { blockTimeStrikeGuessFilterPersonEQ              :: Maybe (UUID Person)
+  , blockTimeStrikeGuessFilterPersonNEQ             :: Maybe (UUID Person)
     -- guess
-  , blockTimeStrikeGuessResultFilterGuessEQ               :: Maybe SlowFast
-  , blockTimeStrikeGuessResultFilterGuessNEQ              :: Maybe SlowFast
-    -- observedResult
-  , blockTimeStrikeGuessResultFilterObservedResultEQ      :: Maybe SlowFast
-  , blockTimeStrikeGuessResultFilterObservedResultNEQ     :: Maybe SlowFast
+  , blockTimeStrikeGuessFilterGuessEQ               :: Maybe SlowFast
+  , blockTimeStrikeGuessFilterGuessNEQ              :: Maybe SlowFast
+    -- observed
+  , blockTimeStrikeGuessFilterObservedResultEQ      :: Maybe SlowFast
+  , blockTimeStrikeGuessFilterObservedResultNEQ     :: Maybe SlowFast
     -- strike block height
-  , blockTimeStrikeGuessResultFilterStrikeBlockHeightGTE  :: Maybe BlockHeight
-  , blockTimeStrikeGuessResultFilterStrikeBlockHeightLTE  :: Maybe BlockHeight
-  , blockTimeStrikeGuessResultFilterStrikeBlockHeightEQ   :: Maybe BlockHeight
-  , blockTimeStrikeGuessResultFilterStrikeBlockHeightNEQ  :: Maybe BlockHeight
+  , blockTimeStrikeGuessFilterStrikeBlockHeightGTE  :: Maybe BlockHeight
+  , blockTimeStrikeGuessFilterStrikeBlockHeightLTE  :: Maybe BlockHeight
+  , blockTimeStrikeGuessFilterStrikeBlockHeightEQ   :: Maybe BlockHeight
+  , blockTimeStrikeGuessFilterStrikeBlockHeightNEQ  :: Maybe BlockHeight
     -- strike strikeMediantime
-  , blockTimeStrikeGuessResultFilterStrikeMediantimeGTE   :: Maybe POSIXTime
-  , blockTimeStrikeGuessResultFilterStrikeMediantimeLTE   :: Maybe POSIXTime
-  , blockTimeStrikeGuessResultFilterStrikeMediantimeEQ    :: Maybe POSIXTime
-  , blockTimeStrikeGuessResultFilterStrikeMediantimeNEQ   :: Maybe POSIXTime
+  , blockTimeStrikeGuessFilterStrikeMediantimeGTE   :: Maybe POSIXTime
+  , blockTimeStrikeGuessFilterStrikeMediantimeLTE   :: Maybe POSIXTime
+  , blockTimeStrikeGuessFilterStrikeMediantimeEQ    :: Maybe POSIXTime
+  , blockTimeStrikeGuessFilterStrikeMediantimeNEQ   :: Maybe POSIXTime
     -- sort
-  , blockTimeStrikeGuessResultFilterSort                  :: Maybe SortOrder
-  , blockTimeStrikeGuessResultFilterClass                 :: Maybe BlockTimeStrikeFilterClass
-  , blockTimeStrikeGuessResultFilterLinesPerPage          :: Maybe (Positive Int)
+  , blockTimeStrikeGuessFilterSort                  :: Maybe SortOrder
+  , blockTimeStrikeGuessFilterClass                 :: Maybe BlockTimeStrikeFilterClass
+  , blockTimeStrikeGuessFilterLinesPerPage          :: Maybe (Positive Int)
   }
   deriving (Eq, Show, Generic)
-instance Default BlockTimeStrikeGuessResultFilter where
-  def = defaultBlockTimeStrikeGuessResultFilter
-instance ToJSON BlockTimeStrikeGuessResultFilter where
+instance Default BlockTimeStrikeGuessFilter where
+  def = defaultBlockTimeStrikeGuessFilter
+instance ToJSON BlockTimeStrikeGuessFilter where
   toJSON = commonToJSON genericToJSON
   toEncoding = commonToJSON genericToEncoding
-instance FromJSON BlockTimeStrikeGuessResultFilter where
+instance FromJSON BlockTimeStrikeGuessFilter where
   parseJSON = commonParseJSON
-instance ToSchema BlockTimeStrikeGuessResultFilter where
+instance ToSchema BlockTimeStrikeGuessFilter where
   declareNamedSchema proxy = genericDeclareNamedSchema defaultSchemaOptions proxy
     & mapped.schema.description ?~ (Text.unlines
-      [ "This is the example of the public filter available for BlockTimeStrikeGuessResult"
+      [ "This is the example of the public filter available for BlockTimeStrikeGuess"
       , "each field is optional and can be provided in a combination of unique fields to build specific filter"
       ])
-    & mapped.schema.example ?~ toJSON defaultBlockTimeStrikeGuessResultFilter
-instance ToParamSchema BlockTimeStrikeGuessResultFilter where
+    & mapped.schema.example ?~ toJSON defaultBlockTimeStrikeGuessFilter
+instance ToParamSchema BlockTimeStrikeGuessFilter where
   toParamSchema v = mempty
     & type_ ?~ SwaggerString
     & format ?~ ( Text.unlines
@@ -147,10 +118,10 @@ instance ToParamSchema BlockTimeStrikeGuessResultFilter where
     where
       def1 :: Default a => Proxy a-> a
       def1 = def
-instance ToHttpApiData BlockTimeStrikeGuessResultFilter where
+instance ToHttpApiData BlockTimeStrikeGuessFilter where
   toUrlPiece v = toUrlPiece $ Text.decodeUtf8 $ BS.toStrict $ encode v
   toQueryParam v = toQueryParam $ Text.decodeUtf8 $ BS.toStrict $ encode v
-instance FromHttpApiData BlockTimeStrikeGuessResultFilter where
+instance FromHttpApiData BlockTimeStrikeGuessFilter where
   parseUrlPiece v = case Aeson.eitherDecodeStrict (Text.encodeUtf8 v) of
     Left some -> Left (Text.pack some)
     Right some -> Right some
@@ -158,23 +129,23 @@ instance FromHttpApiData BlockTimeStrikeGuessResultFilter where
     Left some -> Left (Text.pack some)
     Right some -> Right some
 
-defaultBlockTimeStrikeGuessResultFilter :: BlockTimeStrikeGuessResultFilter
-defaultBlockTimeStrikeGuessResultFilter =  BlockTimeStrikeGuessResultFilter
-  { blockTimeStrikeGuessResultFilterPersonEQ              = Just defaultUUID
-  , blockTimeStrikeGuessResultFilterPersonNEQ             = Just defaultUUID
-  , blockTimeStrikeGuessResultFilterGuessEQ               = Just Slow
-  , blockTimeStrikeGuessResultFilterGuessNEQ              = Just Fast
-  , blockTimeStrikeGuessResultFilterObservedResultEQ      = Just Slow
-  , blockTimeStrikeGuessResultFilterObservedResultNEQ     = Just Fast
-  , blockTimeStrikeGuessResultFilterStrikeBlockHeightGTE  = Just 1
-  , blockTimeStrikeGuessResultFilterStrikeBlockHeightLTE  = Just 1
-  , blockTimeStrikeGuessResultFilterStrikeBlockHeightEQ   = Just 1
-  , blockTimeStrikeGuessResultFilterStrikeBlockHeightNEQ  = Just 1
-  , blockTimeStrikeGuessResultFilterStrikeMediantimeGTE   = Just 1
-  , blockTimeStrikeGuessResultFilterStrikeMediantimeLTE   = Just 1
-  , blockTimeStrikeGuessResultFilterStrikeMediantimeEQ    = Just 1
-  , blockTimeStrikeGuessResultFilterStrikeMediantimeNEQ   = Just 1
-  , blockTimeStrikeGuessResultFilterSort                  = Just Descend
-  , blockTimeStrikeGuessResultFilterClass                 = Just defaultBlockTimeStrikeFilterClass
-  , blockTimeStrikeGuessResultFilterLinesPerPage          = Just 100
+defaultBlockTimeStrikeGuessFilter :: BlockTimeStrikeGuessFilter
+defaultBlockTimeStrikeGuessFilter =  BlockTimeStrikeGuessFilter
+  { blockTimeStrikeGuessFilterPersonEQ              = Just defaultUUID
+  , blockTimeStrikeGuessFilterPersonNEQ             = Just defaultUUID
+  , blockTimeStrikeGuessFilterGuessEQ               = Just Slow
+  , blockTimeStrikeGuessFilterGuessNEQ              = Just Fast
+  , blockTimeStrikeGuessFilterObservedResultEQ      = Just Slow
+  , blockTimeStrikeGuessFilterObservedResultNEQ     = Just Fast
+  , blockTimeStrikeGuessFilterStrikeBlockHeightGTE  = Just 1
+  , blockTimeStrikeGuessFilterStrikeBlockHeightLTE  = Just 1
+  , blockTimeStrikeGuessFilterStrikeBlockHeightEQ   = Just 1
+  , blockTimeStrikeGuessFilterStrikeBlockHeightNEQ  = Just 1
+  , blockTimeStrikeGuessFilterStrikeMediantimeGTE   = Just 1
+  , blockTimeStrikeGuessFilterStrikeMediantimeLTE   = Just 1
+  , blockTimeStrikeGuessFilterStrikeMediantimeEQ    = Just 1
+  , blockTimeStrikeGuessFilterStrikeMediantimeNEQ   = Just 1
+  , blockTimeStrikeGuessFilterSort                  = Just Descend
+  , blockTimeStrikeGuessFilterClass                 = Just defaultBlockTimeStrikeFilterClass
+  , blockTimeStrikeGuessFilterLinesPerPage          = Just 100
   }

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/Account/Server/V1/Person.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/Account/Server/V1/Person.hs
@@ -58,9 +58,9 @@ Person
   deriving Eq Show Generic
 |]
 
-instance API.BuildFilter Person API.BlockTimeStrikeGuessResultFilter where
-  sortOrder (filter, _) = maybe Descend id (API.blockTimeStrikeGuessResultFilterSort filter)
-  buildFilter ( API.BlockTimeStrikeGuessResultFilter
+instance API.BuildFilter Person API.BlockTimeStrikeGuessFilter where
+  sortOrder (filter, _) = maybe Descend id (API.blockTimeStrikeGuessFilterSort filter)
+  buildFilter ( API.BlockTimeStrikeGuessFilter
                 mPersonEQ
                 mPersonNEQ
                 -- guess

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1.hs
@@ -57,53 +57,59 @@ import qualified OpEnergy.BlockTimeStrike.Server.V1.Class as BlockTime(State(..)
 
 blockTimeServer :: ServerT BlockTimeV1API (AppT Handler)
 blockTimeServer = websocketHandler
-  :<|> ((createBlockTimeStrikeFuture
+  :<|> ((createBlockTimeStrikeFutureHandler
         ) :: API.AccountToken
           -> BlockHeight
           -> Natural Int
           -> AppM ()
        )
-  :<|>((OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeGuessService.createBlockTimeStrikeFutureGuess
+  :<|>((OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeGuessService.createBlockTimeStrikeFutureGuessHandler
        ) :: API.AccountToken
          -> BlockHeight
          -> Natural Int
          -> API.SlowFast
          -> AppM API.BlockTimeStrikeGuess
       )
-  :<|> ((OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeService.getBlockTimeStrikesPage
+  :<|> ((OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeService.getBlockTimeStrikesPageHandler
         ) :: Maybe (Natural Int)
           -> Maybe (API.FilterRequest API.BlockTimeStrike API.BlockTimeStrikeFilter)
           -> AppM (API.PagingResult API.BlockTimeStrikeWithGuessesCount)
        )
-  :<|> ((OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeGuessService.getBlockTimeStrikesGuessesPage
+  :<|> ((OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeGuessService.getBlockTimeStrikesGuessesPageHandler
         ) :: Maybe (Natural Int)
-          -> Maybe (API.FilterRequest API.BlockTimeStrikeGuess API.BlockTimeStrikeGuessResultFilter)
-          -> AppM (API.PagingResult API.BlockTimeStrikeGuessResult)
+          -> Maybe ( API.FilterRequest
+                     API.BlockTimeStrikeGuess
+                     API.BlockTimeStrikeGuessFilter
+                   )
+          -> AppM (API.PagingResult API.BlockTimeStrikeGuess)
        )
-  :<|> ((OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeGuessService.getBlockTimeStrikeGuessesPage
+  :<|> ((OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeGuessService.getBlockTimeStrikeGuessesPageHandler
         ) :: BlockHeight
           -> Natural Int
           -> Maybe (Natural Int)
-          -> Maybe (API.FilterRequest API.BlockTimeStrikeGuess API.BlockTimeStrikeGuessResultFilter)
-          -> AppM (API.PagingResult API.BlockTimeStrikeGuessResult)
+          -> Maybe ( API.FilterRequest
+                     API.BlockTimeStrikeGuess
+                     API.BlockTimeStrikeGuessFilter
+                   )
+          -> AppM (API.PagingResult API.BlockTimeStrikeGuess)
        )
 
-  :<|> ((OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeService.getBlockTimeStrike
+  :<|> ((OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeService.getBlockTimeStrikeHandler
         ) :: BlockHeight
           -> Natural Int
           -> AppM API.BlockTimeStrikeWithGuessesCount
        )
-  :<|> ((OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeGuessService.getBlockTimeStrikeGuess
+  :<|> ((OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeGuessService.getBlockTimeStrikeGuessHandler
         ) :: API.AccountToken
           -> BlockHeight
           -> Natural Int
-          -> AppM API.BlockTimeStrikeGuessResult
+          -> AppM API.BlockTimeStrikeGuess
        )
-  :<|> ((OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeGuessService.getBlockTimeStrikeGuessPerson
+  :<|> ((OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeGuessService.getBlockTimeStrikeGuessPersonHandler
         ) :: API.UUID API.Person
           -> BlockHeight
           -> Natural Int
-          -> AppM API.BlockTimeStrikeGuessResult
+          -> AppM API.BlockTimeStrikeGuess
        )
   :<|>  oeGitHashGet
   where

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrike.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrike.hs
@@ -71,9 +71,9 @@ BlockTimeStrikeObserved
 
 |]
 
-instance BuildFilter BlockTimeStrike BlockTimeStrikeGuessResultFilter where
-  sortOrder (filter, _) = maybe Descend id (blockTimeStrikeGuessResultFilterSort filter)
-  buildFilter ( BlockTimeStrikeGuessResultFilter
+instance BuildFilter BlockTimeStrike BlockTimeStrikeGuessFilter where
+  sortOrder (filter, _) = maybe Descend id (blockTimeStrikeGuessFilterSort filter)
+  buildFilter ( BlockTimeStrikeGuessFilter
                 -- person
                 _
                 _
@@ -150,9 +150,9 @@ instance BuildFilter BlockTimeStrikeObserved API.BlockTimeStrikeFilter where
                      ]) mobservedResultNEQ
     ]
 
-instance BuildFilter BlockTimeStrikeObserved BlockTimeStrikeGuessResultFilter where
-  sortOrder (filter, _) = maybe Descend id (blockTimeStrikeGuessResultFilterSort filter)
-  buildFilter ( BlockTimeStrikeGuessResultFilter
+instance BuildFilter BlockTimeStrikeObserved BlockTimeStrikeGuessFilter where
+  sortOrder (filter, _) = maybe Descend id (blockTimeStrikeGuessFilterSort filter)
+  buildFilter ( BlockTimeStrikeGuessFilter
                 -- person
                 _
                 _

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeGuess.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeGuess.hs
@@ -67,15 +67,15 @@ CalculatedBlockTimeStrikeGuessesCount
   deriving Eq Show Generic
 |]
 
-instance API.BuildFilter BlockTimeStrikeGuess API.BlockTimeStrikeGuessResultFilter where
-  sortOrder (filter, _) = fromMaybe Descend (API.blockTimeStrikeGuessResultFilterSort filter)
-  buildFilter ( API.BlockTimeStrikeGuessResultFilter
+instance API.BuildFilter BlockTimeStrikeGuess API.BlockTimeStrikeGuessFilter where
+  sortOrder (filter, _) = fromMaybe Descend (API.blockTimeStrikeGuessFilterSort filter)
+  buildFilter ( API.BlockTimeStrikeGuessFilter
                 _
                 _
                 -- guess
                 mGuessEQ
                 mGuessNEQ
-                -- observedResult
+                -- observed
                 _
                 _
                 -- strike block height

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeGuessService.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeGuessService.hs
@@ -599,7 +599,7 @@ getBlockTimeStrikeGuessPerson uuid blockHeight strikeMediantime =
   mpersonE <- exceptTMaybeT "DB query errors, check logs" $ mgetPersonByUUID uuid
   personE <- exceptTMaybeT "person was not able to authenticate itself"
     $ return mpersonE
-  mstrike <- exceptTMaybeT "DB query errrors, see logs for details"
+  mstrike <- exceptTMaybeT "DB query errors, see logs for details"
     $ actualGetStrikeGuess personE blockHeight (fromIntegral strikeMediantime)
   exceptTMaybeT "no strike or guess found"
     $ return mstrike

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeGuessService.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeGuessService.hs
@@ -100,7 +100,8 @@ createBlockTimeStrikeFutureGuessHandler
     in profile name $
   eitherThrowJSON
     (\reason-> do
-      let msg = "getBlockTimeStrikesGuessesPage: " <> reason
+      callstack <- asks callStack
+      let msg = callstack <> ": " <> reason
       runLogging $ $(logError) msg
       return (err500, msg)
     )
@@ -265,7 +266,8 @@ getBlockTimeStrikesGuessesPageHandler mpage mfilterAPI =
     in profile name $ do
   eitherThrowJSON
     (\reason-> do
-      let msg = "getBlockTimeStrikesGuessesPage: " <> reason
+      callstack <- asks callStack
+      let msg = callstack <> ": " <> reason
       runLogging $ $(logError) msg
       return (err500, msg)
     )
@@ -446,7 +448,8 @@ getBlockTimeStrikeGuessesPageHandler
     in profile name $
   eitherThrowJSON
     (\reason-> do
-      let msg = name <> ": " <> reason
+      callstack <- asks callStack
+      let msg = callstack <> ": " <> reason
       runLogging $ $(logError) msg
       return (err500, msg)
     )
@@ -520,8 +523,9 @@ getBlockTimeStrikeGuessHandler token blockHeight strikeMediantime =
     in profile name $ eitherThrowJSON
       (\reason-> do
         callstack <- asks callStack
-        runLogging $ $(logError) $ callstack <> ":" <> reason
-        return (err500, reason)
+        let msg = callstack <> ": " <> reason
+        runLogging $ $(logError) msg
+        return (err500, msg)
       )
       $ runExceptPrefixT name $ do
   ExceptT $ getBlockTimeStrikeGuess token blockHeight strikeMediantime
@@ -581,7 +585,7 @@ getBlockTimeStrikeGuessPersonHandler uuid blockHeight strikeMediantime =
   eitherThrowJSON
     (\reason-> do
       callstack <- asks callStack
-      let msg = callstack <> ": " <> name <> ": " <> reason
+      let msg = callstack <> ": " <> reason
       runLogging $ $(logError) msg
       return (err500, msg)
     )

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeGuessService.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeGuessService.hs
@@ -7,25 +7,30 @@
 {-# LANGUAGE GADTs                     #-}
 module OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeGuessService
   ( createBlockTimeStrikeFutureGuess
+  , createBlockTimeStrikeFutureGuessHandler
   , getBlockTimeStrikeGuessResultsPage
+  , getBlockTimeStrikesGuessesPageHandler
   , getBlockTimeStrikesGuessesPage
   , getBlockTimeStrikeGuessesPage
+  , getBlockTimeStrikeGuessesPageHandler
   , getBlockTimeStrikeGuess
+  , getBlockTimeStrikeGuessHandler
+  , getBlockTimeStrikeGuessPersonHandler
   , getBlockTimeStrikeGuessPerson
   ) where
 
-import           Servant (err400, err500)
+import           Servant ( err500)
 import           Control.Monad.Trans.Reader (asks, ReaderT(..))
 import           Control.Monad.Logger( logError, NoLoggingT)
 import           Data.Time.Clock( getCurrentTime)
 import           Data.Time.Clock.POSIX(POSIXTime, utcTimeToPOSIXSeconds)
 import qualified Control.Concurrent.STM as STM
 import qualified Control.Concurrent.STM.TVar as TVar
-import           Control.Monad(void)
+import           Control.Monad(void, when)
 import qualified Data.List as List
 import           Data.Text(Text)
 import           Control.Monad.Trans.Resource( ResourceT)
-import           Control.Monad.Trans.Except( runExceptT, ExceptT(..))
+import           Control.Monad.Trans.Except( runExceptT, ExceptT(..), throwE)
 import           Data.Maybe(fromMaybe)
 
 import           Data.Conduit ((.|), ConduitT)
@@ -55,7 +60,7 @@ import           Data.OpEnergy.Account.API.V1.BlockTimeStrikeFilterClass
 import           Data.OpEnergy.API.V1.Error (throwJSON)
 
 import           OpEnergy.ExceptMaybe(exceptTMaybeT)
-import           OpEnergy.Error( eitherThrowJSON)
+import           OpEnergy.Error( eitherThrowJSON, runExceptPrefixT)
 import           OpEnergy.PagingResult( pagingResult)
 import           OpEnergy.Account.Server.V1.Config (Config(..))
 import           OpEnergy.Account.Server.V1.Class ( AppT, AppM, State(..), runLogging, profile, withDBTransaction)
@@ -83,55 +88,61 @@ mgetBlockTimeStrikeFuture blockHeight strikeMediantime = profile "mgetBlockTimeS
 
 -- | O(ln accounts).
 -- Tries to create future block time strike. Requires authenticated user and blockheight should be in the future
-createBlockTimeStrikeFutureGuess
+createBlockTimeStrikeFutureGuessHandler
   :: API.AccountToken
   -> BlockHeight
   -> Natural Int
   -> API.SlowFast
   -> AppM API.BlockTimeStrikeGuess
-createBlockTimeStrikeFutureGuess token blockHeight strikeMediantime guess = profile "createBlockTimeStrikeFutureGuess" $ do
-  configBlockTimeStrikeGuessMinimumBlockAheadCurrentTip <- asks (configBlockTimeStrikeGuessMinimumBlockAheadCurrentTip . config)
-  latestConfirmedBlockV <- asks (BlockTime.latestConfirmedBlock . blockTimeState)
-  mlatestConfirmedBlock <- liftIO $ TVar.readTVarIO latestConfirmedBlockV
-  case mlatestConfirmedBlock of
-    Nothing -> do
-      let err = "ERROR: createBlockTimeStrikeFutureGuess: there is no current tip yet"
-      runLogging $ $(logError) err
-      throwJSON err500 err
-    Just tip
-        | blockHeaderMediantime tip > fromIntegral strikeMediantime -> do
-        let err = "ERROR: createBlockTimeStrikeFutureGuess: strikeMediantime is in the past, which is not expected"
-        runLogging $ $(logError) err
-        throwJSON err400 err
-    Just tip
-      | blockHeaderHeight tip + naturalFromPositive configBlockTimeStrikeGuessMinimumBlockAheadCurrentTip > blockHeight -> do
-        let err = "ERROR: createBlockTimeStrikeFutureGuess: block height for new block time strike should be in the future + minimum configBlockTimeStrikeFutureGuessMinimumBlockAheadCurrentTip"
-        runLogging $ $(logError) err
-        throwJSON err400 err
-    _ -> do
-      mperson <- mgetPersonByAccountToken token
-      case mperson of
-        Nothing-> do
-          let err = "ERROR: createBlockTimeStrikeFutureGuess: person was not able to authenticate itself"
-          runLogging $ $(logError) err
-          throwJSON err400 err
-        Just (Entity personKey person) -> do
-          mstrike <- mgetBlockTimeStrikeFuture blockHeight strikeMediantime
-          case mstrike of
-            Nothing-> do
-              let err = "ERROR: createBlockTimeStrikeFutureGuess: future strike was not able to authenticate itself"
-              runLogging $ $(logError) err
-              throwJSON err400 err
-            Just (Entity strikeKey strike) -> do
-              mret <- createBlockTimeStrikeFutureGuess personKey strikeKey guess
-              case mret of
-                Nothing -> throwJSON err500 ("something went wrong"::Text)
-                Just v -> return $ API.BlockTimeStrikeGuess
-                  { API.person = apiModelUUIDPerson $ personUuid person
-                  , API.strike = apiModelBlockTimeStrike strike Nothing
-                  , API.creationTime = blockTimeStrikeGuessCreationTime v
-                  , API.guess = guess
-                  }
+createBlockTimeStrikeFutureGuessHandler
+    token blockHeight strikeMediantime guess =
+    let name = "BlockTimeStrikeGuessService.createBlockTimeStrikeFutureGuessHandler"
+    in profile name $
+  eitherThrowJSON
+    (\reason-> do
+      let msg = "getBlockTimeStrikesGuessesPage: " <> reason
+      runLogging $ $(logError) msg
+      return (err500, msg)
+    )
+    $ createBlockTimeStrikeFutureGuess token blockHeight strikeMediantime guess
+
+createBlockTimeStrikeFutureGuess
+  :: API.AccountToken
+  -> BlockHeight
+  -> Natural Int
+  -> API.SlowFast
+  -> AppM (Either Text API.BlockTimeStrikeGuess)
+createBlockTimeStrikeFutureGuess token blockHeight strikeMediantime guess =
+    let name = "BlockTimeStrikeGuessService.createBlockTimeStrikeFutureGuess"
+    in profile name $ runExceptPrefixT name $ do
+  configBlockTimeStrikeGuessMinimumBlockAheadCurrentTip <- lift
+    $ asks (configBlockTimeStrikeGuessMinimumBlockAheadCurrentTip . config)
+  latestConfirmedBlockV <- lift
+    $ asks (BlockTime.latestConfirmedBlock . blockTimeState)
+  tip <- exceptTMaybeT "there is no current tip yet"
+    $ liftIO $ TVar.readTVarIO latestConfirmedBlockV
+  when (blockHeaderMediantime tip > fromIntegral strikeMediantime)
+    $ throwE "strikeMediantime is in the past, which is not expected"
+  when ( blockHeaderHeight tip
+       + naturalFromPositive configBlockTimeStrikeGuessMinimumBlockAheadCurrentTip
+       > blockHeight)
+    $ throwE "block height for new block time strike should be in the future \
+             \+ minimum configBlockTimeStrikeFutureGuessMinimumBlockAheadCurrentTip"
+  Entity personKey person <- exceptTMaybeT
+    "person was not able to authenticate itself"
+    $ mgetPersonByAccountToken token
+  Entity strikeKey strike <- exceptTMaybeT
+    "future strike was not able to authenticate itself"
+    $ mgetBlockTimeStrikeFuture blockHeight strikeMediantime
+  v <- exceptTMaybeT
+    "something went wrong"
+    $ createBlockTimeStrikeFutureGuess personKey strikeKey guess
+  return $ API.BlockTimeStrikeGuess
+    { API.person = apiModelUUIDPerson $ personUuid person
+    , API.strike = apiModelBlockTimeStrike strike Nothing
+    , API.creationTime = blockTimeStrikeGuessCreationTime v
+    , API.guess = guess
+    }
   where
     createBlockTimeStrikeFutureGuess
       :: (MonadMonitor m, MonadIO m)
@@ -168,8 +179,8 @@ createBlockTimeStrikeFutureGuess token blockHeight strikeMediantime guess = prof
 -- returns list BlockTimeStrikePast records
 getBlockTimeStrikeGuessResultsPage
   :: Maybe (Natural Int)
-  -> Maybe (API.FilterRequest API.BlockTimeStrikeGuess API.BlockTimeStrikeGuessResultFilter)
-  -> AppM (API.PagingResult API.BlockTimeStrikeGuessResult)
+  -> Maybe (API.FilterRequest API.BlockTimeStrikeGuess API.BlockTimeStrikeGuessFilter)
+  -> AppM (API.PagingResult API.BlockTimeStrikeGuess)
 getBlockTimeStrikeGuessResultsPage mpage mfilterAPI = profile "getBlockTimeStrikeGuessResultsPage" $ do
   mconfirmedBlockV <- asks ( BlockTime.latestConfirmedBlock . blockTimeState)
   mconfirmedBlock <- liftIO $ TVar.readTVarIO mconfirmedBlockV
@@ -186,7 +197,7 @@ getBlockTimeStrikeGuessResultsPage mpage mfilterAPI = profile "getBlockTimeStrik
           linesPerPage = maybe
             recordsPerReply
             ( fromMaybe recordsPerReply
-            . API.blockTimeStrikeGuessResultFilterLinesPerPage
+            . API.blockTimeStrikeGuessFilterLinesPerPage
             . fst
             . API.unFilterRequest
             )
@@ -214,8 +225,8 @@ getBlockTimeStrikeGuessResultsPage mpage mfilterAPI = profile "getBlockTimeStrik
     sort = maybe Descend (API.sortOrder . API.unFilterRequest . id1 . API.mapFilter) mfilter
       where
         id1
-          :: API.FilterRequest BlockTimeStrike API.BlockTimeStrikeGuessResultFilter
-          -> API.FilterRequest BlockTimeStrike API.BlockTimeStrikeGuessResultFilter
+          :: API.FilterRequest BlockTimeStrike API.BlockTimeStrikeGuessFilter
+          -> API.FilterRequest BlockTimeStrike API.BlockTimeStrikeGuessFilter
         id1 = id -- helping typechecker
     filters recordsPerReply confirmedBlock =
       fetchConfirmedStrikes recordsPerReply confirmedBlock
@@ -245,48 +256,70 @@ getBlockTimeStrikeGuessResultsPage mpage mfilterAPI = profile "getBlockTimeStrik
 
 
 -- | returns list BlockTimeStrikeGuess records
-getBlockTimeStrikesGuessesPage
+getBlockTimeStrikesGuessesPageHandler
   :: Maybe (Natural Int)
-  -> Maybe (API.FilterRequest API.BlockTimeStrikeGuess API.BlockTimeStrikeGuessResultFilter)
-  -> AppM (API.PagingResult API.BlockTimeStrikeGuessResult)
-getBlockTimeStrikesGuessesPage mpage mfilterAPI = profile "getBlockTimeStrikesGuessesPage" $ do
-  latestUnconfirmedBlockHeightV <- asks (BlockTime.latestUnconfirmedBlockHeight . blockTimeState)
-  configBlockTimeStrikeGuessMinimumBlockAheadCurrentTip <- asks (configBlockTimeStrikeGuessMinimumBlockAheadCurrentTip . config)
-  latestConfirmedBlockV <- asks (BlockTime.latestConfirmedBlock . blockTimeState)
-  recordsPerReply <- asks (configRecordsPerReply . config)
-  let
-      linesPerPage = maybe recordsPerReply (maybe recordsPerReply id . API.blockTimeStrikeGuessResultFilterLinesPerPage . fst . API.unFilterRequest ) mfilter
+  -> Maybe (API.FilterRequest API.BlockTimeStrikeGuess API.BlockTimeStrikeGuessFilter)
+  -> AppM (API.PagingResult API.BlockTimeStrikeGuess)
+getBlockTimeStrikesGuessesPageHandler mpage mfilterAPI =
+    let name = "getBlockTimeStrikesGuessesPageHandler"
+    in profile name $ do
   eitherThrowJSON
     (\reason-> do
       let msg = "getBlockTimeStrikesGuessesPage: " <> reason
       runLogging $ $(logError) msg
       return (err500, msg)
     )
-    $ runExceptT $ do
-      (latestUnconfirmedBlockHeight, latestConfirmedBlock) <- ExceptT
-        $ liftIO $ STM.atomically $ runExceptT $ (,)
-          <$> (exceptTMaybeT "latest unconfirmed block hasn't been received yet"
-              $ TVar.readTVar latestUnconfirmedBlockHeightV
-              )
-          <*> ( exceptTMaybeT "latest confirmed block hasn't been received yet"
-              $ TVar.readTVar latestConfirmedBlockV
-              )
-      let
-          finalStrikesFilter =
-            BlockTimeStrikeFilter.buildFilterByClass
-              (maybe Nothing (API.blockTimeStrikeGuessResultFilterClass . fst . API.unFilterRequest) mfilter)
-              latestUnconfirmedBlockHeight
-              latestConfirmedBlock
-              configBlockTimeStrikeGuessMinimumBlockAheadCurrentTip
-            ++ strikeFilter
-      exceptTMaybeT "db query failed"
-        $ pagingResult
-          mpage
-          linesPerPage
-          guessFilter
-          sort
-          BlockTimeStrikeGuessId
-          $ streamGuessStrikeObservedResultAndOwner finalStrikesFilter linesPerPage
+    $ getBlockTimeStrikesGuessesPage mpage mfilterAPI
+
+-- | returns list BlockTimeStrikeGuess records
+getBlockTimeStrikesGuessesPage
+  :: Maybe (Natural Int)
+  -> Maybe (API.FilterRequest API.BlockTimeStrikeGuess API.BlockTimeStrikeGuessFilter)
+  -> AppM (Either Text (API.PagingResult API.BlockTimeStrikeGuess))
+getBlockTimeStrikesGuessesPage mpage mfilterAPI =
+    let name = "getBlockTimeStrikesGuessesPage"
+    in profile name $ runExceptPrefixT name $ do
+  latestUnconfirmedBlockHeightV <- lift
+    $ asks (BlockTime.latestUnconfirmedBlockHeight . blockTimeState)
+  configBlockTimeStrikeGuessMinimumBlockAheadCurrentTip <- lift
+    $ asks (configBlockTimeStrikeGuessMinimumBlockAheadCurrentTip . config)
+  latestConfirmedBlockV <- lift
+    $ asks (BlockTime.latestConfirmedBlock . blockTimeState)
+  recordsPerReply <- lift
+    $ asks (configRecordsPerReply . config)
+  let
+      linesPerPage = maybe
+        recordsPerReply
+        ( fromMaybe recordsPerReply
+        . API.blockTimeStrikeGuessFilterLinesPerPage
+        . fst
+        . API.unFilterRequest
+        )
+        mfilter
+  (latestUnconfirmedBlockHeight, latestConfirmedBlock) <- ExceptT
+    $ liftIO $ STM.atomically $ runExceptT $ (,)
+      <$> (exceptTMaybeT "latest unconfirmed block hasn't been received yet"
+          $ TVar.readTVar latestUnconfirmedBlockHeightV
+          )
+      <*> ( exceptTMaybeT "latest confirmed block hasn't been received yet"
+          $ TVar.readTVar latestConfirmedBlockV
+          )
+  let
+      finalStrikesFilter =
+        BlockTimeStrikeFilter.buildFilterByClass
+          (maybe Nothing (API.blockTimeStrikeGuessFilterClass . fst . API.unFilterRequest) mfilter)
+          latestUnconfirmedBlockHeight
+          latestConfirmedBlock
+          configBlockTimeStrikeGuessMinimumBlockAheadCurrentTip
+        ++ strikeFilter
+  exceptTMaybeT "db query failed"
+    $ pagingResult
+      mpage
+      linesPerPage
+      guessFilter
+      sort
+      BlockTimeStrikeGuessId
+      $ streamGuessStrikeObservedResultAndOwner finalStrikesFilter linesPerPage
   where
     mfilter = fmap coerceFilterRequestBlockTimeStrikeGuess mfilterAPI
     strikeFilter :: [Filter BlockTimeStrike]
@@ -296,8 +329,8 @@ getBlockTimeStrikesGuessesPage mpage mfilterAPI = profile "getBlockTimeStrikesGu
     sort = maybe Descend (API.sortOrder . API.unFilterRequest . id1 . API.mapFilter) mfilter
       where
         id1
-          :: API.FilterRequest BlockTimeStrike API.BlockTimeStrikeGuessResultFilter
-          -> API.FilterRequest BlockTimeStrike API.BlockTimeStrikeGuessResultFilter
+          :: API.FilterRequest BlockTimeStrike API.BlockTimeStrikeGuessFilter
+          -> API.FilterRequest BlockTimeStrike API.BlockTimeStrikeGuessFilter
         id1 = id -- helping typechecker
 
     streamGuessStrikeObservedResultAndOwner
@@ -305,7 +338,7 @@ getBlockTimeStrikesGuessesPage mpage mfilterAPI = profile "getBlockTimeStrikesGu
       -> Positive Int
       -> ConduitT
            (Entity BlockTimeStrikeGuess)
-           API.BlockTimeStrikeGuessResult
+           API.BlockTimeStrikeGuess
            (ReaderT SqlBackend (NoLoggingT (ResourceT IO)))
            ()
     streamGuessStrikeObservedResultAndOwner finalFilter linesPerPage
@@ -343,7 +376,7 @@ getBlockTimeStrikesGuessesPage mpage mfilterAPI = profile "getBlockTimeStrikesGu
             (guess, strikeE@(Entity strikeId _)) = do
           case maybe
               Nothing
-              (API.blockTimeStrikeGuessResultFilterClass
+              (API.blockTimeStrikeGuessFilterClass
               . fst
               . API.unFilterRequest
               )
@@ -401,50 +434,69 @@ getBlockTimeStrikesGuessesPage mpage mfilterAPI = profile "getBlockTimeStrikesGu
 
 
 -- | returns list BlockTimeStrikeGuesses records
+getBlockTimeStrikeGuessesPageHandler
+  :: BlockHeight
+  -> Natural Int
+  -> Maybe (Natural Int)
+  -> Maybe (API.FilterRequest API.BlockTimeStrikeGuess API.BlockTimeStrikeGuessFilter)
+  -> AppM (API.PagingResult API.BlockTimeStrikeGuess)
+getBlockTimeStrikeGuessesPageHandler
+  strikeBlockHeight strikeMediantime mpage mfilterAPI =
+    let name = "V1.BlockTimeStrikeGuessService.getBlockTimeStrikeGuessesPageHandler"
+    in profile name $
+  eitherThrowJSON
+    (\reason-> do
+      let msg = name <> ": " <> reason
+      runLogging $ $(logError) msg
+      return (err500, msg)
+    )
+    $ getBlockTimeStrikeGuessesPage strikeBlockHeight strikeMediantime mpage
+      mfilterAPI
+
+-- | returns list BlockTimeStrikeGuesses records
 getBlockTimeStrikeGuessesPage
   :: BlockHeight
   -> Natural Int
   -> Maybe (Natural Int)
-  -> Maybe (API.FilterRequest API.BlockTimeStrikeGuess API.BlockTimeStrikeGuessResultFilter)
-  -> AppM (API.PagingResult API.BlockTimeStrikeGuessResult)
-getBlockTimeStrikeGuessesPage blockHeight strikeMediantime mpage mfilterAPI = profile "getBlockTimeStrikeGuessesPage" $ do
-  recordsPerReply <- asks (configRecordsPerReply . config)
+  -> Maybe (API.FilterRequest API.BlockTimeStrikeGuess API.BlockTimeStrikeGuessFilter)
+  -> AppM (Either Text (API.PagingResult API.BlockTimeStrikeGuess))
+getBlockTimeStrikeGuessesPage blockHeight strikeMediantime mpage mfilterAPI =
+    let name = "getBlockTimeStrikeGuessesPage"
+    in profile name $ runExceptPrefixT name $ do
+  recordsPerReply <- lift $ asks (configRecordsPerReply . config)
   let
       linesPerPage = maybe
                        recordsPerReply
                        ( fromMaybe recordsPerReply
-                       . API.blockTimeStrikeGuessResultFilterLinesPerPage
+                       . API.blockTimeStrikeGuessFilterLinesPerPage
                        . fst
                        . API.unFilterRequest
                        )
                        mfilter
-  mret <- withDBTransaction "" $ do
-    C.runConduit
-      $ filters linesPerPage
-      .| (C.drop (fromNatural page * fromPositive linesPerPage) >> C.awaitForever C.yield) -- navigate to page
-      .| C.map renderBlockTimeStrikeGuessResult
-      .| C.take (fromPositive linesPerPage + 1) -- we take +1 to understand if there is a next page available
-  case mret of
-      Nothing -> do
-        throwJSON err500 ("something went wrong, check logs for details"::Text)
-      Just guessesTail-> do
-        let newPage =
-              if List.length guessesTail > fromPositive linesPerPage
-              then Just (fromIntegral (fromNatural page + 1))
-              else Nothing
-            results = List.take (fromPositive linesPerPage) guessesTail
-        return $ API.PagingResult
-          { API.pagingResultNextPage = newPage
-          , API.pagingResultResults = results
-          }
+  guessesTail <- exceptTMaybeT "something went wrong, check logs for details"
+    $ withDBTransaction "" $ do
+      C.runConduit
+        $ filters linesPerPage
+        .| (C.drop (fromNatural page * fromPositive linesPerPage) >> C.awaitForever C.yield) -- navigate to page
+        .| C.map renderBlockTimeStrikeGuessResult
+        .| C.take (fromPositive linesPerPage + 1) -- we take +1 to understand if there is a next page available
+  let newPage =
+        if List.length guessesTail > fromPositive linesPerPage
+        then Just (fromIntegral (fromNatural page + 1))
+        else Nothing
+      results = List.take (fromPositive linesPerPage) guessesTail
+  return $ API.PagingResult
+    { API.pagingResultNextPage = newPage
+    , API.pagingResultResults = results
+    }
   where
     page = fromMaybe 0 mpage
     mfilter = fmap coerceFilterRequestBlockTimeStrikeGuess mfilterAPI
     sort = maybe Descend (API.sortOrder . API.unFilterRequest . id1 . API.mapFilter) mfilter
       where
         id1
-          :: API.FilterRequest BlockTimeStrike API.BlockTimeStrikeGuessResultFilter
-          -> API.FilterRequest BlockTimeStrike API.BlockTimeStrikeGuessResultFilter
+          :: API.FilterRequest BlockTimeStrike API.BlockTimeStrikeGuessFilter
+          -> API.FilterRequest BlockTimeStrike API.BlockTimeStrikeGuessFilter
         id1 = id -- helping typechecker
     filters recordsPerReply =
       fetchBlockTimeStrikeByHeightAndMediantime recordsPerReply sort
@@ -458,31 +510,36 @@ getBlockTimeStrikeGuessesPage blockHeight strikeMediantime mpage mfilterAPI = pr
       .| C.mapM maybeFetchObservedStrikeByStrikeGuessAndPersonAndFlatten
 
 -- | returns BlockTimeStrikeGuess by strike and person, taken from account token
+getBlockTimeStrikeGuessHandler
+  :: API.AccountToken
+  -> BlockHeight
+  -> Natural Int
+  -> AppM API.BlockTimeStrikeGuess
+getBlockTimeStrikeGuessHandler token blockHeight strikeMediantime =
+    let name = "V1.BlockTimeStrikeGuessService.getBlockTimeStrikeGuessHandler"
+    in profile name $ eitherThrowJSON
+      (\reason-> do
+        callstack <- asks callStack
+        runLogging $ $(logError) $ callstack <> ":" <> reason
+        return (err500, reason)
+      )
+      $ runExceptPrefixT name $ do
+  ExceptT $ getBlockTimeStrikeGuess token blockHeight strikeMediantime
+
 getBlockTimeStrikeGuess
   :: API.AccountToken
   -> BlockHeight
   -> Natural Int
-  -> AppM API.BlockTimeStrikeGuessResult
-getBlockTimeStrikeGuess token blockHeight strikeMediantime = profile "getBlockTimeStrikeGuess" $ do
-  mperson <- mgetPersonByAccountToken token
-  case mperson of
-    Nothing-> do
-      let err = "ERROR: getBlockTimeStrikeGuess: person was not able to authenticate itself"
-      runLogging $ $(logError) err
-      throwJSON err400 err
-    Just personE -> do
-      mstrike <- actualGetStrikeGuess personE blockHeight (fromIntegral strikeMediantime)
-      case mstrike of
-        Nothing-> do
-          let err = "ERROR: getBlockTimeStrikeGuess: something went wrong, see logs for details"
-          runLogging $ $(logError) err
-          throwJSON err500 err
-        Just Nothing -> do
-          let err = "ERROR: getBlockTimeStrikeGuess: no strike or guess found"
-          runLogging $ $(logError) err
-          throwJSON err400 err
-        Just (Just ret)-> return ret
-
+  -> AppM (Either Text API.BlockTimeStrikeGuess)
+getBlockTimeStrikeGuess token blockHeight strikeMediantime =
+    let name = "getBlockTimeStrikeGuess"
+    in profile "getBlockTimeStrikeGuess" $ runExceptPrefixT name $ do
+  personE <- exceptTMaybeT "person was not able to authenticate itself"
+    $ mgetPersonByAccountToken token
+  mGuess <- exceptTMaybeT "something went wrong, see logs for details"
+    $ actualGetStrikeGuess personE blockHeight (fromIntegral strikeMediantime)
+  exceptTMaybeT "no strike or guess found"
+    $ return mGuess
   where
     actualGetStrikeGuess (Entity personKey person) blockHeight strikeMediantime = do
       recordsPerReply <- asks (configRecordsPerReply . config)
@@ -513,35 +570,39 @@ getBlockTimeStrikeGuess token blockHeight strikeMediantime = profile "getBlockTi
         []
       return (strikeE, guessE, mObserved)
 
-getBlockTimeStrikeGuessPerson
+getBlockTimeStrikeGuessPersonHandler
   :: UUID API.Person
   -> BlockHeight
   -> Natural Int
-  -> AppM API.BlockTimeStrikeGuessResult
-getBlockTimeStrikeGuessPerson uuid blockHeight strikeMediantime = profile "getBlockTimeStrikeGuessPerson" $ do
-  mperson <- mgetPersonByUUID uuid
-  case mperson of
-    Nothing -> do
-      let err = "ERROR: getBlockTimeStrikeGuessPerson: something went wrong, check logs"
-      runLogging $ $(logError) err
-      throwJSON err500 err
-    Just Nothing-> do
-      let err = "ERROR: getBlockTimeStrikeGuessPerson: person was not able to authenticate itself"
-      runLogging $ $(logError) err
-      throwJSON err400 err
-    Just (Just personE) -> do
-      mstrike <- actualGetStrikeGuess personE blockHeight (fromIntegral strikeMediantime)
-      case mstrike of
-        Nothing-> do
-          let err = "ERROR: getBlockTimeStrikeGuess: something went wrong, see logs for details"
-          runLogging $ $(logError) err
-          throwJSON err500 err
-        Just Nothing -> do
-          let err = "ERROR: getBlockTimeStrikeGuess: no strike or guess found"
-          runLogging $ $(logError) err
-          throwJSON err400 err
-        Just (Just ret)-> return ret
+  -> AppM API.BlockTimeStrikeGuess
+getBlockTimeStrikeGuessPersonHandler uuid blockHeight strikeMediantime =
+    let name = "BlockTimeStrikeGuessService.getBlockTimeStrikeGuessPersonHandler"
+    in profile name $ do
+  eitherThrowJSON
+    (\reason-> do
+      callstack <- asks callStack
+      let msg = callstack <> ": " <> name <> ": " <> reason
+      runLogging $ $(logError) msg
+      return (err500, msg)
+    )
+    $ getBlockTimeStrikeGuessPerson uuid blockHeight strikeMediantime
 
+getBlockTimeStrikeGuessPerson
+  :: (MonadIO m, MonadMonitor m)
+  => UUID API.Person
+  -> BlockHeight
+  -> Natural Int
+  -> AppT m (Either Text API.BlockTimeStrikeGuess)
+getBlockTimeStrikeGuessPerson uuid blockHeight strikeMediantime =
+    let name = "getBlockTimeStrikeGuessPerson"
+    in profile name $ runExceptPrefixT name $ do
+  mpersonE <- exceptTMaybeT "DB query errors, check logs" $ mgetPersonByUUID uuid
+  personE <- exceptTMaybeT "person was not able to authenticate itself"
+    $ return mpersonE
+  mstrike <- exceptTMaybeT "DB query errrors, see logs for details"
+    $ actualGetStrikeGuess personE blockHeight (fromIntegral strikeMediantime)
+  exceptTMaybeT "no strike or guess found"
+    $ return mstrike
   where
     mgetPersonByUUID uuid = do
       withDBTransaction "" $ do
@@ -599,10 +660,10 @@ renderBlockTimeStrikeGuessResultByPerson
      , Entity BlockTimeStrikeGuess
      , Maybe (Entity BlockTimeStrikeObserved)
      )
-  -> API.BlockTimeStrikeGuessResult
+  -> API.BlockTimeStrikeGuess
 renderBlockTimeStrikeGuessResultByPerson person
     (Entity _ strike, Entity _ guess, mObserved) =
-  API.BlockTimeStrikeGuessResult
+  API.BlockTimeStrikeGuess
     { API.person = apiModelUUIDPerson $ personUuid person
     , API.strike = API.BlockTimeStrike
       { API.blockTimeStrikeObservedResult = fmap
@@ -638,7 +699,7 @@ renderBlockTimeStrikeGuessResultByPerson person
 fetchBlockTimeStrikeGuessByStrike
   :: Positive Int
   -> SortOrder
-  -> Maybe (API.FilterRequest BlockTimeStrikeGuess API.BlockTimeStrikeGuessResultFilter)
+  -> Maybe (API.FilterRequest BlockTimeStrikeGuess API.BlockTimeStrikeGuessFilter)
   -> Entity BlockTimeStrike
   -> ConduitT
      ()
@@ -658,7 +719,7 @@ fetchBlockTimeStrikeGuessByStrike recordsPerReply sort mfilter (Entity strikeId 
 fetchGuessPersonByBlockTimeStrikeGuess
   :: Positive Int
   -> SortOrder
-  -> Maybe (API.FilterRequest BlockTimeStrikeGuess API.BlockTimeStrikeGuessResultFilter)
+  -> Maybe (API.FilterRequest BlockTimeStrikeGuess API.BlockTimeStrikeGuessFilter)
   -> ( Entity BlockTimeStrike, Entity BlockTimeStrikeGuess)
   -> ConduitT
      ()
@@ -701,10 +762,10 @@ renderBlockTimeStrikeGuessResult
      , Entity Person
      , Maybe (Entity BlockTimeStrikeObserved)
      )
-  -> API.BlockTimeStrikeGuessResult
+  -> API.BlockTimeStrikeGuess
 renderBlockTimeStrikeGuessResult
     (Entity _ strike, Entity _ guess, Entity _ person, mObserved) =
-  API.BlockTimeStrikeGuessResult
+  API.BlockTimeStrikeGuess
     { person = apiModelUUIDPerson $ personUuid person
     , strike = API.BlockTimeStrike
       { blockTimeStrikeObservedResult = fmap

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeService.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeService.hs
@@ -80,8 +80,9 @@ createBlockTimeStrikeFutureHandler token blockHeight strikeMediantime =
   eitherThrowJSON
     (\reason-> do
       callstack <- asks callStack
-      runLogging $ $(logError) $ callstack <> ": " <> reason
-      return (err500, reason)
+      let msg = callstack <> ": " <> reason
+      runLogging $ $(logError) msg
+      return (err500, msg)
     )
     $ runExceptPrefixT name $ do
     void $ ExceptT $ createBlockTimeStrikeFuture token blockHeight
@@ -171,8 +172,9 @@ getBlockTimeStrikesPageHandler mpage mfilterAPI =
   eitherThrowJSON
     (\reason-> do
       callstack <- asks callStack
-      runLogging $ $(logError) $ callstack <> ": " <> reason
-      return (err500, reason)
+      let msg = callstack <> ": " <> reason
+      runLogging $ $(logError) msg
+      return (err500, msg)
     )
     $ runExceptPrefixT name $ ExceptT $ getBlockTimeStrikesPage mpage mfilterAPI
 
@@ -459,8 +461,9 @@ getBlockTimeStrikeHandler blockHeight strikeMediantime =
     in profile name $ eitherThrowJSON
   (\reason-> do
     callstack <- asks callStack
-    runLogging $ $(logError) $ callstack <> ": " <> reason
-    return (err500, reason)
+    let msg = callstack <> ": " <> reason
+    runLogging $ $(logError) msg
+    return (err500, msg)
   )
   $ getBlockTimeStrike blockHeight strikeMediantime
 

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeService.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeService.hs
@@ -166,7 +166,7 @@ getBlockTimeStrikesPageHandler mpage mfilterAPI =
   eitherThrowJSON
     (\reason-> do
       callstack <- asks callStack
-      runLogging $ $(logError) $ callstack <> ": " <> callstack
+      runLogging $ $(logError) $ callstack <> ": " <> reason
       return (err500, reason)
     )
     $ runExceptPrefixT name $ ExceptT $ getBlockTimeStrikesPage mpage mfilterAPI

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeService.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeService.hs
@@ -80,7 +80,7 @@ createBlockTimeStrikeFutureHandler token blockHeight strikeMediantime =
   eitherThrowJSON
     (\reason-> do
       callstack <- asks callStack
-      runLogging $ $(logError) $ callstack <> ": " <> callstack
+      runLogging $ $(logError) $ callstack <> ": " <> reason
       return (err500, reason)
     )
     $ runExceptPrefixT name $ do

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeService.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeService.hs
@@ -454,7 +454,7 @@ getBlockTimeStrikeHandler blockHeight strikeMediantime =
     in profile name $ eitherThrowJSON
   (\reason-> do
     callstack <- asks callStack
-    runLogging $ $(logError) $ callstack <> ": " <> callstack
+    runLogging $ $(logError) $ callstack <> ": " <> reason
     return (err500, reason)
   )
   $ getBlockTimeStrike blockHeight strikeMediantime

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/Error.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/Error.hs
@@ -40,7 +40,7 @@ eitherThrowJSON handler payload = do
       throwJSON err msg
 
 
--- | The goal of this function is to add prefix to the error reason:w
+-- | The goal of this function is to add prefix to the error reason
 -- example
 -- @ runExceptT "MyFunction" $ throwE "error" @ will return @Left "MyFunction: error"@
 runExceptPrefixT

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/Error.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/Error.hs
@@ -2,11 +2,18 @@
 {-# LANGUAGE FlexibleInstances #-}
 module OpEnergy.Error
   ( eitherThrowJSON
+  , runExceptPrefixT
+  , eitherException
   ) where
 
 import           Data.Text(Text)
+import qualified Data.Text as Text
+
 import           Data.Aeson (ToJSON)
 import           Control.Monad.Error.Class(MonadError)
+import           Control.Monad.Trans.Except(ExceptT, runExceptT)
+import           Control.Exception.Safe (SomeException)
+import qualified Control.Exception.Safe as E
 
 import           Servant(ServerError)
 import           Data.OpEnergy.API.V1.Error(throwJSON)
@@ -32,4 +39,37 @@ eitherThrowJSON handler payload = do
       (err, msg) <- handler reason
       throwJSON err msg
 
+
+-- | The goal of this function is to add prefix to the error reason:w
+-- example
+-- @ runExceptT "MyFunction" $ throwE "error" @ will return @Left "MyFunction: error"@
+runExceptPrefixT
+  :: Monad m
+  => Text
+  -> ExceptT Text m r
+  -> m (Either Text r)
+runExceptPrefixT prefix payload = do
+  eret <- runExceptT payload
+  return $! either
+    (\reason-> Left (prefix <> ": " <> reason))
+    Right
+    eret
+
+-- | this functions's goal is to handle possible exception into @Either@ type
+-- in order to wrap side-effectful routine into ExceptT transformer
+-- Example:
+-- @ eitherException $ readFile "/file/not/found" @
+eitherException
+  :: IO r
+  -> IO (Either Text r)
+eitherException next = do
+  !ret <- E.handle
+    (\(e::SomeException)->
+      return (Left (Text.pack (show e)))
+    )
+    (do
+      !ret <- next
+      return (Right ret)
+    )
+  return ret
 

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/Error.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/Error.hs
@@ -42,7 +42,9 @@ eitherThrowJSON handler payload = do
 
 -- | The goal of this function is to add prefix to the error reason
 -- example
--- @ runExceptT "MyFunction" $ throwE "error" @ will return @Left "MyFunction: error"@
+-- ```haskell
+-- runExceptPrefixT "MyFunction" $ throwE "error" -- will return @Left "MyFunction: error"@
+-- ```
 runExceptPrefixT
   :: Monad m
   => Text


### PR DESCRIPTION
This PR is the part 2 of the big one: https://github.com/op-energy-foundation/op-energy/pull/72

This PR depends on https://github.com/op-energy-foundation/op-energy/pull/73 as uses it as a base

This PR contains:
1. no additional functionality other than small utility functions `runExceptPrefixT` and `eitherException` to help working with functions built on top of ExceptT monad transformer;
2. renaming BlockTimeStrikeGuessResult* datatypes into BlockTimeStrikeGuess* as those are similar now and in order to address confusion from 'api review' document;
3. cleanup of `pagingResult` function