### PR TITLE
PART4: various fixes

### DIFF
--- a/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeService.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/BlockTimeStrikeService.hs
@@ -9,10 +9,9 @@ module OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeService
   ( createBlockTimeStrikeFutureHandler
   , createBlockTimeStrikeFuture
   , newTipHandlerLoop
-  , getBlockTimeStrikesPage
-  , getBlockTimeStrikesPageHandler
   , getBlockTimeStrike
   , getBlockTimeStrikeHandler
+  , module OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeService.GetBlockTimeStrikesPage
   ) where
 
 import           Servant ( err500, err400, ServerError)
@@ -32,7 +31,6 @@ import           Control.Monad.Trans
 import           Control.Monad.Trans.Except
                    ( runExceptT, ExceptT (..), throwE)
 import           Control.Monad.Trans.Resource( ResourceT)
-import           Data.Maybe( fromMaybe)
 
 import           Database.Persist
 import           Database.Persist.Sql
@@ -46,21 +44,18 @@ import           Data.OpEnergy.API.V1.Block
 import           Data.OpEnergy.API.V1.Natural
 import           Data.OpEnergy.API.V1.Positive( naturalFromPositive, fromPositive)
 import qualified Data.OpEnergy.Account.API.V1.BlockTimeStrike            as API
-import qualified Data.OpEnergy.Account.API.V1.PagingResult               as API
-import qualified Data.OpEnergy.Account.API.V1.FilterRequest              as API
-import qualified Data.OpEnergy.Account.API.V1.BlockTimeStrikeFilterClass as API
 
 import           OpEnergy.ExceptMaybe(exceptTMaybeT)
 import           OpEnergy.Error( eitherThrowJSON, runExceptPrefixT)
-import           OpEnergy.PagingResult
 import qualified OpEnergy.BlockTimeStrike.Server.V1.Class as BlockTime
-import qualified OpEnergy.BlockTimeStrike.Server.V1.BlockTimeScheduledStrikeCreation as BlockTimeScheduledStrikeCreation
+import qualified OpEnergy.BlockTimeStrike.Server.V1.BlockTimeScheduledStrikeCreation
+                 as BlockTimeScheduledStrikeCreation
 import qualified OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeObserve as Observe
 import qualified OpEnergy.BlockTimeStrike.Server.V1.Context as Context
-import qualified OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeFilter as BlockTimeStrikeFilter
 import           OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrike
 import           OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeGuess
 import qualified OpEnergy.BlockTimeStrike.Server.V1.SlowFast as SlowFast
+import           OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeService.GetBlockTimeStrikesPage
 import           OpEnergy.Account.Server.V1.Config
                  as Config(Config(..))
 import           OpEnergy.Account.Server.V1.AccountService (mgetPersonByAccountToken)
@@ -164,306 +159,6 @@ newTipHandlerLoop = forever $ do
     Observe.withLeastUnobservedConfirmedBlock confirmedTip $ \leastUnobservedConfirmedBlock-> do
       Observe.observeStrikes leastUnobservedConfirmedBlock
       BlockTimeScheduledStrikeCreation.maybeCreateStrikes $! Context.unContext leastUnobservedConfirmedBlock
-
-data IsSortByGuessesCountNeeded
-  = SortByGuessesCountNotNeeded
-  | SortByGuessesCountNeeded
-
--- | returns list of BlockTimeStrike records
-getBlockTimeStrikesPageHandler
-  :: Maybe (Natural Int)
-  -> Maybe (API.FilterRequest API.BlockTimeStrike API.BlockTimeStrikeFilter)
-  -> AppM (API.PagingResult API.BlockTimeStrikeWithGuessesCount)
-getBlockTimeStrikesPageHandler mpage mfilterAPI =
-    let name = "V1.getBlockTimeStrikesPageHandler"
-    in profile name $ do
-  eitherThrowJSON
-    (\reason-> do
-      callstack <- asks callStack
-      let msg = callstack <> ": " <> reason
-      runLogging $ $(logError) msg
-      return msg
-    )
-    $ runExceptPrefixT name $ ExceptT $ getBlockTimeStrikesPage mpage mfilterAPI
-
-getBlockTimeStrikesPage
-  :: ( MonadIO m
-     , MonadMonitor m
-     )
-  => Maybe (Natural Int)
-  -> Maybe (API.FilterRequest API.BlockTimeStrike API.BlockTimeStrikeFilter)
-  -> AppT m (Either (ServerError, Text) (API.PagingResult API.BlockTimeStrikeWithGuessesCount))
-getBlockTimeStrikesPage mpage mfilterAPI =
-    let name = "getBlockTimeStrikesPage"
-    in profile name $ runExceptPrefixT name $ do
-  latestUnconfirmedBlockHeightV <- lift $ asks (BlockTime.latestUnconfirmedBlockHeight . blockTimeState)
-  configBlockTimeStrikeGuessMinimumBlockAheadCurrentTip <- lift $ asks (configBlockTimeStrikeGuessMinimumBlockAheadCurrentTip . config)
-  latestConfirmedBlockV <- lift $ asks (BlockTime.latestConfirmedBlock . blockTimeState)
-  (latestUnconfirmedBlockHeight, latestConfirmedBlock) <-
-    ExceptT $ liftIO $ STM.atomically $ runExceptT $ (,)
-      <$> (exceptTMaybeT (err500, "latest unconfirmed block hasn't been received yet")
-          $ TVar.readTVar latestUnconfirmedBlockHeightV
-          )
-      <*> (exceptTMaybeT (err500, "latest confirmed block hasn't been received yet")
-          $ TVar.readTVar latestConfirmedBlockV
-          )
-  let
-      staticPartFilter = maybe
-                           []
-                           ( API.buildFilter
-                           . API.unFilterRequest
-                           . API.mapFilter
-                           )
-                           mfilter
-      strikeFilter =
-        BlockTimeStrikeFilter.buildFilterByClass
-          ( maybe
-            Nothing
-            ( API.blockTimeStrikeFilterClass
-            . fst
-            . API.unFilterRequest
-            ) mfilter
-          )
-          latestUnconfirmedBlockHeight
-          latestConfirmedBlock
-          configBlockTimeStrikeGuessMinimumBlockAheadCurrentTip
-        ++ staticPartFilter
-  exceptTMaybeT ( err500, "getBlockTimeStrikePast failed")
-    $ getBlockTimeStrikePast strikeFilter
-  where
-    mfilter = fmap coerceFilterRequestBlockTimeStrike mfilterAPI
-    sort = maybe
-             Descend
-             ( API.sortOrder
-             . API.unFilterRequest
-             )
-             mfilter
-    getBlockTimeStrikePast
-      :: ( MonadIO m
-         , MonadMonitor m
-         )
-      => [Filter BlockTimeStrike]
-      -> ReaderT
-         State
-         m
-         (Maybe (API.PagingResult API.BlockTimeStrikeWithGuessesCount))
-    getBlockTimeStrikePast strikeFilter = do
-      recordsPerReply <- asks (configRecordsPerReply . config)
-      let
-          linesPerPage = maybe
-            recordsPerReply
-            ( fromMaybe recordsPerReply
-            . API.blockTimeStrikeFilterLinesPerPage
-            . fst
-            . API.unFilterRequest
-            )
-            mfilter
-      let
-          eGuessesCount = case maybe
-                API.StrikeSortOrderDescend
-                ( fromMaybe API.StrikeSortOrderDescend
-                . API.blockTimeStrikeFilterSort
-                . fst
-                . API.unFilterRequest
-                )
-                mfilter
-              of
-            API.StrikeSortOrderAscend -> SortByGuessesCountNotNeeded
-            API.StrikeSortOrderDescend -> SortByGuessesCountNotNeeded
-            API.StrikeSortOrderAscendGuessesCount ->  SortByGuessesCountNeeded
-            API.StrikeSortOrderDescendGuessesCount -> SortByGuessesCountNeeded
-      case eGuessesCount of
-        SortByGuessesCountNotNeeded -> pagingResult
-          mpage
-          linesPerPage
-          strikeFilter
-          sort
-          BlockTimeStrikeId -- select strikes with given filter first
-          $  C.map guessesCountWillBeFetchedLater
-          .| C.concatMapM maybeFetchObservedStrike
-          .| C.concatMapM maybeFetchGuessesCount
-          .| C.concatMapM unwrapGuessesCount
-          .| C.map renderBlockTimeStrike
-        SortByGuessesCountNeeded -> pagingResult
-          mpage
-          linesPerPage
-          []
-          sort
-          CalculatedBlockTimeStrikeGuessesCountGuessesCount
-          $  C.concatMapM (fetchStrikeByGuessesCount strikeFilter)
-          .| C.map guessesCountAlreadyFetched
-          .| C.concatMapM maybeFetchObservedStrike
-          .| C.concatMapM unwrapGuessesCount
-          .| C.map renderBlockTimeStrike
-    guessesCountWillBeFetchedLater
-      :: Entity BlockTimeStrike
-      -> ( Maybe (Entity CalculatedBlockTimeStrikeGuessesCount)
-         , Entity BlockTimeStrike
-         )
-    guessesCountWillBeFetchedLater strikeE = (Nothing, strikeE)
-    guessesCountAlreadyFetched
-      :: ( Entity CalculatedBlockTimeStrikeGuessesCount
-         , Entity BlockTimeStrike
-         )
-      -> ( Maybe (Entity CalculatedBlockTimeStrikeGuessesCount)
-         , Entity BlockTimeStrike
-         )
-    guessesCountAlreadyFetched (guessE, strikeE) = (Just guessE, strikeE)
-    maybeFetchGuessesCount
-      :: ( Entity BlockTimeStrike
-         , Maybe (Entity BlockTimeStrikeObserved)
-         , Maybe (Entity CalculatedBlockTimeStrikeGuessesCount)
-         )
-      -> (ReaderT SqlBackend (NoLoggingT (ResourceT IO)))
-         [( Entity BlockTimeStrike
-          , Maybe (Entity BlockTimeStrikeObserved)
-          , Maybe (Entity CalculatedBlockTimeStrikeGuessesCount)
-          )
-         ]
-    maybeFetchGuessesCount (strikeE@(Entity strikeId _), mObserved, mguessesCount) = do
-      case mguessesCount of
-        Just _ -> return [(strikeE, mObserved, mguessesCount)]
-        Nothing -> do
-          mguessesCountFound <- selectFirst
-            [ CalculatedBlockTimeStrikeGuessesCountStrike ==. strikeId]
-            []
-          case mguessesCountFound of
-            Just _ -> thereWereGuessesMade
-              where
-                thereWereGuessesMade = return [(strikeE, mObserved, mguessesCountFound)]
-            Nothing -> noGuessesMadeYet
-              where
-                noGuessesMadeYet = return [(strikeE, mObserved, Nothing)]
-    fetchStrikeByGuessesCount
-      :: [Filter BlockTimeStrike]
-      -> Entity CalculatedBlockTimeStrikeGuessesCount
-      -> (ReaderT SqlBackend (NoLoggingT (ResourceT IO)))
-         [(Entity CalculatedBlockTimeStrikeGuessesCount, Entity BlockTimeStrike)]
-    fetchStrikeByGuessesCount strikeFilter guessE@(Entity _ guessesCount) = do
-      mstrike <- selectFirst
-        ((BlockTimeStrikeId ==. calculatedBlockTimeStrikeGuessesCountStrike guessesCount)
-         :strikeFilter
-        )
-        []
-      case mstrike of
-        Just strikeE-> return [(guessE, strikeE)]
-        Nothing -> return []
-    maybeFetchObservedStrike
-      :: ( Maybe (Entity CalculatedBlockTimeStrikeGuessesCount)
-         , Entity BlockTimeStrike
-         )
-      -> (ReaderT SqlBackend (NoLoggingT (ResourceT IO)))
-         [( Entity BlockTimeStrike
-          , Maybe (Entity BlockTimeStrikeObserved)
-          , Maybe (Entity CalculatedBlockTimeStrikeGuessesCount)
-          )
-         ]
-    maybeFetchObservedStrike (mguessesCount, strikeE@(Entity strikeId _)) = do
-      anyValidObservedStrike <- tryFetchValidObservedStrikeByClass
-      case anyValidObservedStrike of
-        Nothing -> return [ ]
-        Just maybeObservedStrike ->
-          return [ (strikeE, maybeObservedStrike, mguessesCount)]
-      where
-      tryFetchValidObservedStrikeByClass = do
-        let
-            anyStrikeClassConstraintByFilter = maybe
-              Nothing
-              ( API.blockTimeStrikeFilterClass
-              . fst
-              . API.unFilterRequest
-              ) mfilter
-        case anyStrikeClassConstraintByFilter of
-          Nothing -> do
-            let
-                observedStrikeFilter = maybe
-                  [] ( API.buildFilter
-                     . API.unFilterRequest
-                     . API.mapFilter
-                     ) mfilter
-            anyObservedStrike <- selectFirst
-              ( ( BlockTimeStrikeObservedStrike ==. strikeId
-                )
-              : observedStrikeFilter
-              ) []
-            case (observedStrikeFilter, anyObservedStrike) of
-              ([], classDoNotConstraintExistenceOfObservedStrike) ->
-                return (Just classDoNotConstraintExistenceOfObservedStrike)
-              ( _nonEmptyObservedStrikeFilter: _ , Just observedBlockFitsFilter)->
-                return (Just (Just observedBlockFitsFilter))
-              (_observedStrikeFilterExistsButObservedStrikeMissing :_ , Nothing) ->
-                return Nothing
-          Just API.BlockTimeStrikeFilterClassGuessable->
-            return (Just Nothing) -- strike has not been observed and strikeFilter should ensure, that it is in the future with proper guess threshold
-          Just API.BlockTimeStrikeFilterClassOutcomeUnknown-> do
-            return (Just Nothing) -- hasn't been observed
-          Just API.BlockTimeStrikeFilterClassOutcomeKnown-> do
-            -- now get possible observed data for strike
-            anyObservedStrikeFitsOutcomeKnownClass <- selectFirst
-              ( (BlockTimeStrikeObservedStrike ==. strikeId)
-              : maybe [] ( API.buildFilter
-                          . API.unFilterRequest
-                          . API.mapFilter
-                          ) mfilter
-              )
-              []
-            case anyObservedStrikeFitsOutcomeKnownClass of
-              Nothing -> return Nothing
-              Just observedStrikeFitsOutcomeKnownClass ->
-                return (Just (Just observedStrikeFitsOutcomeKnownClass)) -- had been observed
-    renderBlockTimeStrike
-      :: ( Entity BlockTimeStrike
-         , Maybe (Entity BlockTimeStrikeObserved)
-         , Natural Int
-         )
-      -> API.BlockTimeStrikeWithGuessesCount
-    renderBlockTimeStrike (Entity _ strike, mObserved, guessesCount) =
-      API.BlockTimeStrikeWithGuessesCount
-        { blockTimeStrikeWithGuessesCountStrike = API.BlockTimeStrike
-          { blockTimeStrikeObservedResult = fmap
-            (\(Entity _ v)-> SlowFast.apiModel $ blockTimeStrikeObservedIsFast v)
-            mObserved
-          , blockTimeStrikeObservedBlockMediantime = fmap
-            (\(Entity _ v)-> blockTimeStrikeObservedJudgementBlockMediantime v)
-            mObserved
-          , blockTimeStrikeObservedBlockHash = fmap
-            (\(Entity _ v)-> blockTimeStrikeObservedJudgementBlockHash v)
-            mObserved
-          , blockTimeStrikeObservedBlockHeight = fmap
-            (\(Entity _ v)-> blockTimeStrikeObservedJudgementBlockHeight v)
-            mObserved
-          , blockTimeStrikeBlock = blockTimeStrikeBlock strike
-          , blockTimeStrikeStrikeMediantime =
-            blockTimeStrikeStrikeMediantime strike
-          , blockTimeStrikeCreationTime =
-            blockTimeStrikeCreationTime strike
-          }
-        , blockTimeStrikeWithGuessesCountGuessesCount =
-          fromIntegral guessesCount
-        }
-    unwrapGuessesCount
-      :: ( Entity BlockTimeStrike
-         , Maybe (Entity BlockTimeStrikeObserved)
-         , Maybe (Entity CalculatedBlockTimeStrikeGuessesCount)
-         )
-      -> (ReaderT SqlBackend (NoLoggingT (ResourceT IO)))
-         [( Entity BlockTimeStrike
-          , Maybe (Entity BlockTimeStrikeObserved)
-          , Natural Int
-          )
-         ]
-    unwrapGuessesCount (strikeE, mObserved, mguessesCount) = do
-      case mguessesCount of
-        Nothing -> thereIsNoGuessesMadeYet
-          where
-            thereIsNoGuessesMadeYet = return [(strikeE, mObserved, 0)]
-        Just (Entity _ guessesCount) ->
-          return [( strikeE
-                  , mObserved
-                  , calculatedBlockTimeStrikeGuessesCountGuessesCount guessesCount
-                  )
-                 ]
-
 
 getBlockTimeStrikeHandler
   :: BlockHeight

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/Class.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V1/Class.hs
@@ -30,3 +30,4 @@ defaultState _ = do
     , blockTimeStrikeConfirmedTip = blockTimeStrikeConfirmedTipV
     , latestUnconfirmedBlockHeight = latestUnconfirmedBlockHeightV
     }
+

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V2/BlockSpanTimeStrikeGuess.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V2/BlockSpanTimeStrikeGuess.hs
@@ -14,6 +14,8 @@ import           Servant ( ServerError)
 import qualified Data.OpEnergy.API.V1.Positive as APIV1
 import qualified Data.OpEnergy.Account.API.V1.BlockTimeStrikeGuess
                  as APIV1
+import qualified Data.OpEnergy.API.V1.Block
+                 as APIV1
 
 import qualified Data.OpEnergy.BlockTime.API.V2.BlockSpanTimeStrikeGuess as API
 
@@ -30,15 +32,17 @@ apiBlockSpanTimeStrikeGuessModelBlockTimeStrikeGuess
   :: ( MonadIO m
      , MonadMonitor m
      )
-  => APIV1.Positive Int
+  => APIV1.BlockHeader
+  -> APIV1.Positive Int
   -> APIV1.BlockTimeStrikeGuess
   -> BlockSpanTimeStrikeGuess.CalculatedBlockTimeStrikeGuessesCount
   -> AppT m (Either (ServerError, Text) API.BlockSpanTimeStrikeGuess)
-apiBlockSpanTimeStrikeGuessModelBlockTimeStrikeGuess spanSize v guessesCount =
+apiBlockSpanTimeStrikeGuessModelBlockTimeStrikeGuess
+  confirmedBlock spanSize v guessesCount =
     let name = "apiBlockSpanTimeStrikeGuessModelBlockTimeStrikeGuess"
     in profile name $ runExceptPrefixT name $ do
   spanStrike <- ExceptT $ BlockSpanTimeStrike.apiBlockSpanTimeStrikeModelBlockTimeStrike
-    spanSize (APIV1.strike v) guessesCount
+    confirmedBlock spanSize (APIV1.strike v) guessesCount
   return $! API.BlockSpanTimeStrikeGuess
     { API.strike = spanStrike
     , API.creationTime = APIV1.creationTime v

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V2/StrikesAPI/GetStrikes.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V2/StrikesAPI/GetStrikes.hs
@@ -179,6 +179,7 @@ getStrikes mspanSize mpage mfilterAPI =
         (APIV1.pagingResultResults blockTimeStrikesGuesses)
         ( \(strike, Entity _ guessesCount) -> ExceptT
           $ BlockSpanTimeStrike.apiBlockSpanTimeStrikeModelBlockTimeStrike
+            latestConfirmedBlock
             spanSize
             strike
             guessesCount


### PR DESCRIPTION
This PR is follow up of the #75 . The reason why this PR is separate from it is just to focus #75 on code reorganization. And this one contains fixes and changes after #75 tests.

This PR includes:
  - fix: V1.BlockTimeStrikeService.getBlockTimeStrikesPage: do not ignore strikes without guesses count
  - fix: apiBlockSpanTimeStrikeModelBlockTimeStrike
    apiBlockSpanTimeStrikeModelBlockTimeStrike is now decides if block had been observed by latest confirmed block instead of observedResult as result can be observed by mediantime meaning that block header of the block strike's height is not yet available. 
    Initially, in case if there were no guesses made yet we had counted guesses in place. But, this action had been considered as an incorrect behavior of the function named 'get'. So counting had been removed and no replacement had been introduced until now.
    Now, missing guesses count record treated as there were no guesses made yet. We can assume that because there were a migration of the CalculatedBlockTimeStrikeGuessesCount table, which include appropriate calculation. Though, this migration should create a record in this table in case if there were actual guesses had been made. And, such record are created during creating a guess. So there should be no other reasons why calculated guesses count record is missing other than missing guesses until the date.

  - refactor: V1/BlockTimeStrikeService/GetBlockTimeStrikesPage.hs    
    functions are now refactored to be used with Conduit.mapM instead of
    Conduit.concatMapM as they are no longer used as filters, only as maps:
    - maybeFetchGuessesCount

  - refactor: V1.BlockTimeStrikeService: use getBlockTimeStrikesPageHandler / getBlockTimeStrikesPage from V1.BlockTimeStrikeService.GetBlockTimeStrikesPage as they are identical





