### PR TITLE
feat: introduce /api/v2/blockrate/strikes/guesses

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -29,5 +29,5 @@ jobs:
     - run: git submodule set-branch -b devel oe-blockspan-service && git submodule update --remote --recursive
     - run: git config user.name "dev-deploy"; git config user.email "dev@dev.deploy"; git commit -a -m "switch to branch devel"
     - run: git push --force -u origin devel
-    - run: ssh -oStrictHostKeyChecking=no root@${{ vars.DEV_INSTANCE }} "cd /etc/nixos; git pull --rebase; git submodule update --remote --recursive; nixos-rebuild switch"
+    - run: ssh -oStrictHostKeyChecking=no root@${{ vars.DEV_INSTANCE }} "cd /etc/nixos; git pull --rebase; git submodule update --remote --recursive; systemctl stop op-energy-backend-mainnet.service op-energy-account-service.service && nixos-rebuild switch; systemctl start op-energy-backend-mainnet.service op-energy-account-service.service"
 

--- a/oe-account-service/op-energy-account-api/op-energy-account-api.cabal
+++ b/oe-account-service/op-energy-account-api/op-energy-account-api.cabal
@@ -61,6 +61,7 @@ library
                    , Data.OpEnergy.BlockTime.API.V2.StrikesAPI
                    , Data.OpEnergy.BlockTime.API.V2.StrikeAPI
                    , Data.OpEnergy.BlockTime.API.V2.BlockSpanTimeStrikeGuess
+                   , Data.OpEnergy.BlockTime.API.V2.BlockSpanTimeStrikeGuessFilter
                    , Data.OpEnergy.BlockTime.API.V2.GuessAPI
                    , Data.OpEnergy.BlockTime.API.V2.StrikeGuessesAPI
                    , Data.OpEnergy.BlockTime.API.V2.BlockSpanTimeStrikeGuessesSummary

--- a/oe-account-service/op-energy-account-api/src/Data/OpEnergy/BlockTime/API/V2/BlockSpanTimeStrikeGuessFilter.hs
+++ b/oe-account-service/op-energy-account-api/src/Data/OpEnergy/BlockTime/API/V2/BlockSpanTimeStrikeGuessFilter.hs
@@ -124,7 +124,7 @@ instance ToSchema StrikeSortOrder where
 instance ToParamSchema StrikeSortOrder where
   toParamSchema _ = mempty
     & type_ ?~ SwaggerString
-    & enum_ ?~ (map toJSON $ enumFrom Ascend)
+    & enum_ ?~ (map toJSON $ enumFrom StrikeSortOrderAscend)
 instance ToHttpApiData StrikeSortOrder where
   toUrlPiece = Text.pack . show
 instance FromHttpApiData StrikeSortOrder where

--- a/oe-account-service/op-energy-account-api/src/Data/OpEnergy/BlockTime/API/V2/BlockSpanTimeStrikeGuessFilter.hs
+++ b/oe-account-service/op-energy-account-api/src/Data/OpEnergy/BlockTime/API/V2/BlockSpanTimeStrikeGuessFilter.hs
@@ -1,0 +1,154 @@
+{-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE DuplicateRecordFields      #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE UndecidableInstances       #-}
+{-# LANGUAGE DerivingStrategies         #-}
+module Data.OpEnergy.BlockTime.API.V2.BlockSpanTimeStrikeGuessFilter
+  ( BlockSpanTimeStrikeGuessFilter(..)
+  , sortOrderFromStrikeSortOrder
+  , verifyStrikeSortOrderEither
+  , verifyStrikeSortOrder
+  ) where
+
+
+import           Data.Swagger
+import           Control.Lens
+import           GHC.Generics
+import           Data.Aeson as Aeson
+import           Data.Text ( Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import qualified Data.ByteString.Lazy as BS
+import           Data.Time.Clock.POSIX(POSIXTime)
+import qualified Data.List as List
+
+import           Data.Default
+import           Data.Proxy
+import           Servant.API(ToHttpApiData(..), FromHttpApiData(..))
+import           Database.Persist.Pagination(SortOrder(..))
+
+import qualified Data.OpEnergy.Account.API.V1.BlockTimeStrikeFilterClass
+                 as V1
+import           Data.OpEnergy.API.V1.Block(BlockHash, BlockHeight)
+import qualified Data.OpEnergy.API.V1.Hash as BlockHash (defaultHash)
+import           Data.OpEnergy.API.V1.Positive(Positive)
+import           Data.OpEnergy.Account.API.V1.FilterRequest()
+import           Data.OpEnergy.Account.API.V1.SlowFast
+
+
+data BlockSpanTimeStrikeGuessFilter = BlockSpanTimeStrikeGuessFilter
+  { strikeMediantimeGTE        :: Maybe POSIXTime
+  , strikeMediantimeLTE        :: Maybe POSIXTime
+  , strikeMediantimeEQ         :: Maybe POSIXTime
+  , strikeMediantimeNEQ        :: Maybe POSIXTime
+  , strikeBlockHeightGTE       :: Maybe BlockHeight
+  , strikeBlockHeightLTE       :: Maybe BlockHeight
+  , strikeBlockHeightEQ        :: Maybe BlockHeight
+  , strikeBlockHeightNEQ       :: Maybe BlockHeight
+  , observedBlockHashEQ        :: Maybe BlockHash
+  , observedBlockHashNEQ       :: Maybe BlockHash
+  , observedResultEQ           :: Maybe SlowFast
+  , observedResultNEQ          :: Maybe SlowFast
+  , guessEQ                    :: Maybe SlowFast
+  , guessNEQ                   :: Maybe SlowFast
+  , sort                       :: Maybe StrikeSortOrder
+  , _class                     :: Maybe V1.BlockTimeStrikeFilterClass
+  , linesPerPage               :: Maybe (Positive Int)
+  }
+  deriving (Eq, Show, Generic)
+instance ToSchema BlockSpanTimeStrikeGuessFilter where
+  declareNamedSchema proxy = genericDeclareNamedSchema defaultSchemaOptions proxy
+    & mapped.schema.description ?~ Text.unlines
+      [ "This is the example of the public filter available for "
+      , "BlockSpanTimeStrikeGuess"
+      ]
+    & mapped.schema.example ?~ toJSON defaultBlockSpanTimeStrikeGuessFilter
+instance ToParamSchema BlockSpanTimeStrikeGuessFilter where
+  toParamSchema v = mempty
+    & type_ ?~ SwaggerString
+    & format ?~ ( Text.unlines
+                 $ List.map (<>",")
+                 $ Text.splitOn ","
+                 $ Text.decodeUtf8
+                 $ BS.toStrict
+                 $ encode
+                 $ def1 v
+                )
+    where
+      def1 :: Default a => Proxy a-> a
+      def1 = def
+instance ToJSON BlockSpanTimeStrikeGuessFilter
+instance FromJSON BlockSpanTimeStrikeGuessFilter
+instance Default BlockSpanTimeStrikeGuessFilter where
+  def = defaultBlockSpanTimeStrikeGuessFilter
+
+defaultBlockSpanTimeStrikeGuessFilter :: BlockSpanTimeStrikeGuessFilter
+defaultBlockSpanTimeStrikeGuessFilter = BlockSpanTimeStrikeGuessFilter
+  { strikeMediantimeGTE        = Just 1
+  , strikeMediantimeLTE        = Just 1
+  , strikeMediantimeEQ         = Just 2
+  , strikeMediantimeNEQ        = Just 2
+  , strikeBlockHeightGTE       = Just 3
+  , strikeBlockHeightLTE       = Just 3
+  , strikeBlockHeightEQ        = Just 3
+  , strikeBlockHeightNEQ       = Just 3
+  , observedBlockHashEQ        = Just BlockHash.defaultHash
+  , observedBlockHashNEQ       = Just BlockHash.defaultHash
+  , observedResultEQ           = Just Slow
+  , observedResultNEQ          = Just Fast
+  , guessEQ                    = Just Slow
+  , guessNEQ                   = Just Fast
+  , sort                       = Just StrikeSortOrderDescend
+  , _class                     = Just V1.BlockTimeStrikeFilterClassGuessable
+  , linesPerPage               = Just 100
+  }
+
+-- | we need to use separate sort order as we can sort strikes by guesses count
+data StrikeSortOrder
+  = StrikeSortOrderAscend
+  | StrikeSortOrderDescend
+  deriving (Eq, Generic, Bounded, Enum)
+
+instance ToJSON StrikeSortOrder where
+  toJSON = toJSON . Text.pack . show
+instance FromJSON StrikeSortOrder where
+  parseJSON = withText "SortOrder" $! pure . verifyStrikeSortOrder
+instance ToSchema StrikeSortOrder where
+  declareNamedSchema _ = pure $ NamedSchema (Just "SortOrder") $ mempty
+    & type_ ?~ SwaggerString
+instance ToParamSchema StrikeSortOrder where
+  toParamSchema _ = mempty
+    & type_ ?~ SwaggerString
+    & enum_ ?~ (map toJSON $ enumFrom Ascend)
+instance ToHttpApiData StrikeSortOrder where
+  toUrlPiece = Text.pack . show
+instance FromHttpApiData StrikeSortOrder where
+  parseUrlPiece = verifyStrikeSortOrderEither
+
+instance Show StrikeSortOrder where
+  show StrikeSortOrderAscend = "ascend"
+  show StrikeSortOrderDescend = "descend"
+
+sortOrderFromStrikeSortOrder :: StrikeSortOrder -> SortOrder
+sortOrderFromStrikeSortOrder StrikeSortOrderAscend = Ascend
+sortOrderFromStrikeSortOrder StrikeSortOrderDescend = Descend
+
+verifyStrikeSortOrderEither :: Text -> Either Text StrikeSortOrder
+verifyStrikeSortOrderEither t =
+  case found of
+    [] -> Left "verifyStrikeSortOrderEither: wrong value"
+    ((v, _):_) -> Right v
+  where
+    found = List.dropWhile (\(_, v)-> v /= t) $ List.map (\v -> (v, Text.pack (show v))) $ enumFrom minBound
+
+verifyStrikeSortOrder :: Text-> StrikeSortOrder
+verifyStrikeSortOrder v =
+  case verifyStrikeSortOrderEither v of
+    Right some -> some
+    Left some -> error $ Text.unpack some
+

--- a/oe-account-service/op-energy-account-api/src/Data/OpEnergy/BlockTime/API/V2/StrikesAPI.hs
+++ b/oe-account-service/op-energy-account-api/src/Data/OpEnergy/BlockTime/API/V2/StrikesAPI.hs
@@ -8,6 +8,7 @@ import           Servant.API
 
 import           Data.OpEnergy.API.V1.Natural
 import           Data.OpEnergy.API.V1.Positive
+import           Data.OpEnergy.Account.API.V1.Account
 import           Data.OpEnergy.Account.API.V1.PagingResult
 import           Data.OpEnergy.Account.API.V1.FilterRequest
 import           Data.OpEnergy.Account.API.V1.BlockTimeStrike
@@ -15,6 +16,9 @@ import           Data.OpEnergy.Account.API.V1.BlockTimeStrike
                    , BlockTimeStrikeFilter
                    )
 import           Data.OpEnergy.BlockTime.API.V2.BlockSpanTimeStrike
+
+import           Data.OpEnergy.BlockTime.API.V2.BlockSpanTimeStrikeGuess
+import           Data.OpEnergy.BlockTime.API.V2.BlockSpanTimeStrikeGuessFilter
 
 type StrikesAPI
   =    QueryParam'
@@ -54,4 +58,45 @@ type StrikesAPI
                    \by strike id in descending order. \
                    \(ie, from newer to older)"
     :> Get '[JSON] (PagingResult BlockSpanTimeStrike)
+
+  :<|> "guesses"
+    :> Header'
+       '[ Required
+        , Strict
+        , Description "Account token gotten from /login or /register"
+        ]
+       "Authorization"
+       AccountToken -- require authentication
+    :> QueryParam'
+       '[ Optional
+        , Strict
+        , Description "defines block span size"
+        ]
+       "spanSize"
+       (Positive Int)
+    :> QueryParam'
+       '[ Optional
+        , Strict
+        , Description "defines page count to get"
+        ]
+       "page"
+       (Natural Int)
+    :> QueryParam'
+       '[ Optional
+        , Strict
+        , Description "possible filter as a string in JSON format. you can \
+                      \pass any combination of it's unique fields to build a \
+                      \filter. Available filter options are listed in the \
+                      \format of current field. Meaning of fields' suffixes: \
+                      \'GTE' - 'great-than-or-equal', \
+                      \'LTE'- 'less-than-or-equal', \
+                      \'EQ' - equal, 'NEQ' - 'not equal'. \
+                      \'sort' field can have those values: 'descend', \
+                      \'ascend'. 'class' field can have those values: \
+                      \'guessable', 'outcomeKnown', 'outcomeUnknown'"
+        ]
+       "filter"
+       (FilterRequest BlockSpanTimeStrikeGuess BlockSpanTimeStrikeGuessFilter)
+    :> Description "returns list of user's guesses for all strikes"
+    :> Get '[JSON] (PagingResult BlockSpanTimeStrikeGuess)
 

--- a/oe-account-service/op-energy-account-service/op-energy-account-service.cabal
+++ b/oe-account-service/op-energy-account-service/op-energy-account-service.cabal
@@ -86,10 +86,12 @@ library
                    , OpEnergy.BlockTimeStrike.Server.V2
                    , OpEnergy.BlockTimeStrike.Server.V2.StrikesAPI
                    , OpEnergy.BlockTimeStrike.Server.V2.StrikesAPI.GetStrikes
+                   , OpEnergy.BlockTimeStrike.Server.V2.StrikesAPI.GetStrikesGuesses
                    , OpEnergy.BlockTimeStrike.Server.V2.BlockSpanTimeStrike
                    , OpEnergy.BlockTimeStrike.Server.V2.StrikeAPI
                    , OpEnergy.BlockTimeStrike.Server.V2.StrikeAPI.GetStrike
                    , OpEnergy.BlockTimeStrike.Server.V2.BlockSpanTimeStrikeGuess
+                   , OpEnergy.BlockTimeStrike.Server.V2.BlockSpanTimeStrikeGuess.BlockSpanTimeStrikeGuessFilter
                    , OpEnergy.BlockTimeStrike.Server.V2.GuessAPI
                    , OpEnergy.BlockTimeStrike.Server.V2.GuessAPI.Get
                    , OpEnergy.BlockTimeStrike.Server.V2.GuessAPI.Create

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V2/BlockSpanTimeStrikeGuess.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V2/BlockSpanTimeStrikeGuess.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE GADTs                      #-}
 module OpEnergy.BlockTimeStrike.Server.V2.BlockSpanTimeStrikeGuess
   ( apiBlockSpanTimeStrikeGuessModelBlockTimeStrikeGuess
+  , apiBlockSpanTimeStrikeGuessModelBlockTimeStrikeGuess1
   ) where
 
 import           Data.Text (Text)
@@ -23,10 +24,15 @@ import           OpEnergy.Error
                  ( runExceptPrefixT
                  )
 import           OpEnergy.Account.Server.V1.Class ( AppT,  profile )
+import qualified OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrike
+                 as BlockTimeStrike
+import qualified OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeGuess
+                 as BlockTimeStrikeGuess
 import qualified OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeGuess
                  as BlockSpanTimeStrikeGuess
 import qualified OpEnergy.BlockTimeStrike.Server.V2.BlockSpanTimeStrike
                  as BlockSpanTimeStrike
+import qualified OpEnergy.BlockTimeStrike.Server.V1.SlowFast as SlowFast
 
 apiBlockSpanTimeStrikeGuessModelBlockTimeStrikeGuess
   :: ( MonadIO m
@@ -47,5 +53,31 @@ apiBlockSpanTimeStrikeGuessModelBlockTimeStrikeGuess
     { API.strike = spanStrike
     , API.creationTime = APIV1.creationTime v
     , API.guess = APIV1.guess v
+    }
+
+apiBlockSpanTimeStrikeGuessModelBlockTimeStrikeGuess1
+  :: ( MonadIO m
+     , MonadMonitor m
+     )
+  => APIV1.BlockHeader
+  -> APIV1.Positive Int
+  -> BlockTimeStrike.BlockTimeStrike
+  -> Maybe BlockTimeStrike.BlockTimeStrikeObserved
+  -> BlockSpanTimeStrikeGuess.BlockTimeStrikeGuess
+  -> BlockSpanTimeStrikeGuess.CalculatedBlockTimeStrikeGuessesCount
+  -> AppT m (Either (ServerError, Text) API.BlockSpanTimeStrikeGuess)
+apiBlockSpanTimeStrikeGuessModelBlockTimeStrikeGuess1
+  confirmedBlock spanSize strike observed guess guessesCount =
+    let name = "apiBlockSpanTimeStrikeGuessModelBlockTimeStrikeGuess1"
+    in profile name $ runExceptPrefixT name $ do
+  let
+      strikeAPI = BlockTimeStrike.apiModelBlockTimeStrike strike observed
+  spanStrike <- ExceptT $ BlockSpanTimeStrike.apiBlockSpanTimeStrikeModelBlockTimeStrike
+    confirmedBlock spanSize strikeAPI guessesCount
+  return $! API.BlockSpanTimeStrikeGuess
+    { API.strike = spanStrike
+    , API.creationTime = BlockTimeStrikeGuess.blockTimeStrikeGuessCreationTime guess
+    , API.guess = SlowFast.apiModel
+      (BlockTimeStrikeGuess.blockTimeStrikeGuessIsFast guess)
     }
 

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V2/BlockSpanTimeStrikeGuess/BlockSpanTimeStrikeGuessFilter.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V2/BlockSpanTimeStrikeGuess/BlockSpanTimeStrikeGuessFilter.hs
@@ -1,0 +1,124 @@
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE GADTs                      #-}
+module OpEnergy.BlockTimeStrike.Server.V2.BlockSpanTimeStrikeGuess.BlockSpanTimeStrikeGuessFilter
+  where
+
+import qualified Data.List as List
+
+import           Database.Persist
+import           Database.Persist.Pagination
+
+import           Data.OpEnergy.Account.API.V1.FilterRequest
+import qualified Data.OpEnergy.BlockTime.API.V2.BlockSpanTimeStrikeGuessFilter
+                 as BlockSpanTimeStrikeGuessFilter
+
+import qualified OpEnergy.BlockTimeStrike.Server.V1.SlowFast as SlowFast
+import           OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrike
+import           OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeGuess
+
+instance BuildFilter BlockTimeStrike
+    BlockSpanTimeStrikeGuessFilter.BlockSpanTimeStrikeGuessFilter
+    where
+  sortOrder (filter, _) = maybe Descend
+                            BlockSpanTimeStrikeGuessFilter.sortOrderFromStrikeSortOrder
+                            (BlockSpanTimeStrikeGuessFilter.sort filter)
+  buildFilter ( BlockSpanTimeStrikeGuessFilter.BlockSpanTimeStrikeGuessFilter
+                mStrikeMediantimeGTE
+                mStrikeMediantimeLTE
+                mStrikeMediantimeEQ
+                mStrikeMediantimeNEQ
+                mStrikeBlockHeightGTE
+                mStrikeBlockHeightLTE
+                mStrikeBlockHeightEQ
+                mStrikeBlockHeightNEQ
+                _mObservedBlockHashEQ
+                _mObservedBlockHashNEQ
+                _mObservedResultEQ
+                _mObservedResultNEQ
+                _mGuessEQ
+                _mGuessNEQ
+                _mSort
+                _mClass
+                _mLinesPerPage
+              , _
+              ) = List.concat
+        -- strike block height
+    [ maybe [] (\v -> [ BlockTimeStrikeBlock >=. v]) mStrikeBlockHeightGTE
+    , maybe [] (\v -> [ BlockTimeStrikeBlock <=. v]) mStrikeBlockHeightLTE
+    , maybe [] (\v -> [ BlockTimeStrikeBlock ==. v]) mStrikeBlockHeightEQ
+    , maybe [] (\v -> [ BlockTimeStrikeBlock !=. v]) mStrikeBlockHeightNEQ
+    , maybe [] (\v -> [ BlockTimeStrikeStrikeMediantime >=. v]) mStrikeMediantimeGTE
+    , maybe [] (\v -> [ BlockTimeStrikeStrikeMediantime <=. v]) mStrikeMediantimeLTE
+    , maybe [] (\v -> [ BlockTimeStrikeStrikeMediantime ==. v]) mStrikeMediantimeEQ
+    , maybe [] (\v -> [ BlockTimeStrikeStrikeMediantime !=. v]) mStrikeMediantimeNEQ
+    ]
+
+instance BuildFilter BlockTimeStrikeObserved
+    BlockSpanTimeStrikeGuessFilter.BlockSpanTimeStrikeGuessFilter
+    where
+  sortOrder (filter, _) = maybe Descend
+                            BlockSpanTimeStrikeGuessFilter.sortOrderFromStrikeSortOrder
+                            (BlockSpanTimeStrikeGuessFilter.sort filter)
+  buildFilter ( BlockSpanTimeStrikeGuessFilter.BlockSpanTimeStrikeGuessFilter
+                _mStrikeMediantimeGTE
+                _mStrikeMediantimeLTE
+                _mStrikeMediantimeEQ
+                _mStrikeMediantimeNEQ
+                _mStrikeBlockHeightGTE
+                _mStrikeBlockHeightLTE
+                _mStrikeBlockHeightEQ
+                _mStrikeBlockHeightNEQ
+                mObservedBlockHashEQ
+                mObservedBlockHashNEQ
+                mObservedResultEQ
+                mObservedResultNEQ
+                _mGuessEQ
+                _mGuessNEQ
+                _mSort
+                _mClass
+                _mLinesPerPage
+              , _
+              ) = List.concat
+        -- strike block height
+    [ maybe [] (\v -> [ BlockTimeStrikeObservedJudgementBlockHash ==. v])
+      mObservedBlockHashEQ
+    , maybe [] (\v -> [ BlockTimeStrikeObservedJudgementBlockHash !=. v])
+      mObservedBlockHashNEQ
+    , maybe [] (\v -> [ BlockTimeStrikeObservedIsFast ==. SlowFast.modelApi v])
+      mObservedResultEQ
+    , maybe [] (\v -> [ BlockTimeStrikeObservedIsFast !=. SlowFast.modelApi v])
+      mObservedResultNEQ
+    ]
+
+instance BuildFilter BlockTimeStrikeGuess
+    BlockSpanTimeStrikeGuessFilter.BlockSpanTimeStrikeGuessFilter
+    where
+  sortOrder (filter, _) = maybe Descend BlockSpanTimeStrikeGuessFilter.sortOrderFromStrikeSortOrder
+                          (BlockSpanTimeStrikeGuessFilter.sort filter)
+  buildFilter ( BlockSpanTimeStrikeGuessFilter.BlockSpanTimeStrikeGuessFilter
+                _mStrikeMediantimeGTE
+                _mStrikeMediantimeLTE
+                _mStrikeMediantimeEQ
+                _mStrikeMediantimeNEQ
+                _mStrikeBlockHeightGTE
+                _mStrikeBlockHeightLTE
+                _mStrikeBlockHeightEQ
+                _mStrikeBlockHeightNEQ
+                _mObservedBlockHashEQ
+                _mObservedBlockHashNEQ
+                _mObservedResultEQ
+                _mObservedResultNEQ
+                mGuessEQ
+                mGuessNEQ
+                _mSort
+                _mClass
+                _mLinesPerPage
+              , _
+              ) = List.concat
+        -- strike block height
+    [ maybe [] (\v -> [ BlockTimeStrikeGuessIsFast ==. SlowFast.modelApi v]) mGuessEQ
+    , maybe [] (\v -> [ BlockTimeStrikeGuessIsFast !=. SlowFast.modelApi v]) mGuessNEQ
+    ]
+

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V2/StrikesAPI.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V2/StrikesAPI.hs
@@ -12,12 +12,20 @@ import           Data.OpEnergy.API.V1.Positive
 import qualified Data.OpEnergy.Account.API.V1.BlockTimeStrike as API
 import qualified Data.OpEnergy.Account.API.V1.FilterRequest as API
 import qualified Data.OpEnergy.Account.API.V1.PagingResult as API
+import qualified Data.OpEnergy.Account.API.V1.Account
+                 as AccountV1
 import           OpEnergy.Account.Server.V1.Class (AppM, AppT)
 
 import qualified Data.OpEnergy.BlockTime.API.V2.BlockSpanTimeStrike
                  as API
+import qualified Data.OpEnergy.BlockTime.API.V2.BlockSpanTimeStrikeGuess
+                 as API
+import qualified Data.OpEnergy.BlockTime.API.V2.BlockSpanTimeStrikeGuessFilter
+                 as API
 import qualified OpEnergy.BlockTimeStrike.Server.V2.StrikesAPI.GetStrikes
                  as GetStrikes
+import qualified OpEnergy.BlockTimeStrike.Server.V2.StrikesAPI.GetStrikesGuesses
+                 as GetStrikesGuesses
 
 handlers :: ServerT StrikesAPI (AppT Handler)
 handlers
@@ -27,4 +35,12 @@ handlers
           -> Maybe (API.FilterRequest API.BlockTimeStrike API.BlockTimeStrikeFilter)
           -> AppM (API.PagingResult API.BlockSpanTimeStrike)
     )
+
+  :<|> ( GetStrikesGuesses.getStrikesGuessesHandler
+         :: AccountV1.AccountToken
+         -> Maybe (Positive Int)
+         -> Maybe (Natural Int)
+         -> Maybe (API.FilterRequest API.BlockSpanTimeStrikeGuess API.BlockSpanTimeStrikeGuessFilter)
+         -> AppM (API.PagingResult API.BlockSpanTimeStrikeGuess)
+       )
 

--- a/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V2/StrikesAPI/GetStrikesGuesses.hs
+++ b/oe-account-service/op-energy-account-service/src/OpEnergy/BlockTimeStrike/Server/V2/StrikesAPI/GetStrikesGuesses.hs
@@ -1,0 +1,267 @@
+{-- | This module implements BlockTime strike service.
+ -}
+{-# LANGUAGE TemplateHaskell            #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE GADTs                      #-}
+module OpEnergy.BlockTimeStrike.Server.V2.StrikesAPI.GetStrikesGuesses
+  ( getStrikesGuesses
+  , getStrikesGuessesHandler
+  ) where
+
+import           Data.Text(Text)
+import           Servant ( err400, err500, ServerError)
+import           Control.Monad.Trans.Reader ( asks)
+import           Control.Monad.Logger( NoLoggingT, logError)
+import           Control.Monad(forM)
+import           Control.Monad.Reader(ReaderT)
+import           Control.Monad.Trans
+import           Control.Monad.Trans.Except( ExceptT (..))
+import           Data.Maybe( fromMaybe)
+
+import           Data.Proxy(Proxy(..))
+import           Data.Conduit( (.|) )
+import qualified Data.Conduit.List as C
+import           Database.Persist.Pagination(SortOrder(..))
+import           Database.Persist
+import           Database.Persist.Sql
+import           Control.Monad.Trans.Resource( ResourceT)
+
+import qualified Data.OpEnergy.API.V1.Natural as APIV1
+import qualified Data.OpEnergy.API.V1.Positive as APIV1
+import qualified Data.OpEnergy.Account.API.V1.Account
+                 as AccountV1
+import qualified Data.OpEnergy.Account.API.V1.PagingResult
+                 as APIV1
+import qualified Data.OpEnergy.Account.API.V1.FilterRequest
+                 as APIV1
+
+import           Data.OpEnergy.BlockTime.API.V2.BlockSpanTimeStrikeGuess
+import           Data.OpEnergy.BlockTime.API.V2.BlockSpanTimeStrikeGuessFilter
+                 as BlockSpanTimeStrikeGuessFilter
+
+import           OpEnergy.Error( eitherThrowJSON, runExceptPrefixT)
+import           OpEnergy.ExceptMaybe(exceptTMaybeT)
+import qualified OpEnergy.Account.Server.V1.Config as Config
+import           OpEnergy.Account.Server.V1.Class
+                 ( AppM, State(..), runLogging, profile, getCurrentHeaderTip)
+import qualified OpEnergy.Account.Server.V1.AccountService
+                 as V1
+import qualified OpEnergy.PagingResult as PagingResult
+import qualified OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeFilter
+                 as BlockTimeStrikeFilter
+import qualified OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrike
+                 as V1
+import qualified OpEnergy.BlockTimeStrike.Server.V1.BlockTimeStrikeGuess
+                 as V1
+import qualified OpEnergy.BlockTimeStrike.Server.V2.BlockSpanTimeStrikeGuess
+                 as BlockSpanTimeStrikeGuess
+import           OpEnergy.BlockTimeStrike.Server.V2.BlockSpanTimeStrikeGuess.BlockSpanTimeStrikeGuessFilter
+                 ()
+
+-- | this handler returns pageable result of the BlockSpanTimeStrikes for a
+-- given spanSize, page and filter
+getStrikesGuessesHandler
+  :: AccountV1.AccountToken
+  -> Maybe (APIV1.Positive Int)
+  -> Maybe (APIV1.Natural Int)
+  -> Maybe ( APIV1.FilterRequest
+             BlockSpanTimeStrikeGuess
+             BlockSpanTimeStrikeGuessFilter
+           )
+  -> AppM (APIV1.PagingResult BlockSpanTimeStrikeGuess)
+getStrikesGuessesHandler token mspanSize mpage mfilter =
+    let name = "V2.getStrikesGuessesHandler"
+    in profile name $ eitherThrowJSON
+      (\reason-> do
+        callstack <- asks callStack
+        let msg = callstack <> ":" <> reason
+        runLogging $ $(logError) msg
+        return msg
+      )
+      $ getStrikesGuesses token mspanSize mpage mfilter
+
+getStrikesGuesses
+  :: AccountV1.AccountToken
+  -> Maybe (APIV1.Positive Int)
+  -> Maybe (APIV1.Natural Int)
+  -> Maybe ( APIV1.FilterRequest
+             BlockSpanTimeStrikeGuess
+             BlockSpanTimeStrikeGuessFilter
+           )
+  -> AppM (Either (ServerError, Text) (APIV1.PagingResult BlockSpanTimeStrikeGuess))
+getStrikesGuesses token mspanSize mpage mfilterAPI =
+    let name = "V2.getStrikesGuesses"
+    in profile name $ runExceptPrefixT name $ do
+  Entity personKey _ <- exceptTMaybeT
+    (err400, "person was not able to authenticate itself")
+    $ V1.mgetPersonByAccountToken token
+  recordsPerReply <- lift $ asks (Config.configRecordsPerReply . config)
+  let
+      linesPerPage = maybe
+        recordsPerReply
+        ( fromMaybe recordsPerReply
+        . BlockSpanTimeStrikeGuessFilter.linesPerPage
+        . fst
+        . APIV1.unFilterRequest
+        )
+        mfilterGuess
+  configBlockTimeStrikeGuessMinimumBlockAheadCurrentTip <- lift
+    $ asks (Config.configBlockTimeStrikeGuessMinimumBlockAheadCurrentTip . config)
+  (latestUnconfirmedBlockHeight, latestConfirmedBlock) <-
+    ExceptT getCurrentHeaderTip
+  let
+      strikeFilter =
+        BlockTimeStrikeFilter.buildFilterByClass
+          ( maybe
+            Nothing
+            ( BlockSpanTimeStrikeGuessFilter._class
+            . fst
+            . APIV1.unFilterRequest
+            ) mfilter
+          )
+          latestUnconfirmedBlockHeight
+          latestConfirmedBlock
+          configBlockTimeStrikeGuessMinimumBlockAheadCurrentTip
+        ++ strikeStaticPartFilter
+      guessFilter =
+        ( V1.BlockTimeStrikeGuessPerson ==. personKey ) : guessStaticPartFilter
+  spanSize <- lift $ maybe
+    (asks $ Config.configBlockSpanDefaultSize . config)
+    pure
+    mspanSize
+  blockTimeStrikesGuesses <- exceptTMaybeT (err500, "DB query failed")
+    $ PagingResult.pagingResult
+        mpage
+        linesPerPage
+        guessFilter
+        sort
+        V1.BlockTimeStrikeGuessId -- select strikes with given filter first
+        $  C.concatMapM (maybeFetchBlockTimeStrikeByGuess strikeFilter)
+        .| C.concatMapM (fetchBlockTimeStrikeObservedByStrike observedStaticFilter)
+        .| C.concatMapM maybeFetchCalculatedGuessesCount
+  blockSpanTimeStrikesGuessesApi <- forM
+        (APIV1.pagingResultResults blockTimeStrikesGuesses)
+        (   \(Entity _ guess
+             , Entity _ strike
+             , mObserved
+             , Entity _ guessesCount
+             ) -> do
+          ExceptT
+            $ BlockSpanTimeStrikeGuess.apiBlockSpanTimeStrikeGuessModelBlockTimeStrikeGuess1
+              latestConfirmedBlock
+              spanSize
+              strike
+              (fmap (\(Entity _ observed) -> observed) mObserved)
+              guess
+              guessesCount
+        )
+  return $! APIV1.PagingResult
+    { APIV1.pagingResultNextPage =
+      APIV1.pagingResultNextPage blockTimeStrikesGuesses
+    , APIV1.pagingResultResults = blockSpanTimeStrikesGuessesApi
+    }
+  where
+    maybeFetchBlockTimeStrikeByGuess
+      :: [Filter V1.BlockTimeStrike]
+      -> Entity V1.BlockTimeStrikeGuess
+      -> ReaderT SqlBackend (NoLoggingT (ResourceT IO))
+         [(Entity V1.BlockTimeStrikeGuess, Entity V1.BlockTimeStrike)]
+    maybeFetchBlockTimeStrikeByGuess strikeFilter
+        guessE@(Entity _guessId guess) = do
+      maybe [] (\strikeE -> [(guessE, strikeE)])
+        <$> selectFirst
+          ( ( V1.BlockTimeStrikeId ==. V1.blockTimeStrikeGuessStrike guess)
+          : strikeFilter
+          )
+          []
+    fetchBlockTimeStrikeObservedByStrike
+      :: [Filter V1.BlockTimeStrikeObserved]
+      -> (Entity V1.BlockTimeStrikeGuess, Entity V1.BlockTimeStrike)
+      -> ReaderT SqlBackend (NoLoggingT (ResourceT IO))
+         [ ( Entity V1.BlockTimeStrikeGuess
+           , Entity V1.BlockTimeStrike
+           , Maybe (Entity V1.BlockTimeStrikeObserved)
+           )
+         ]
+    fetchBlockTimeStrikeObservedByStrike observedStaticFilter
+        (guessE, strikeE@(Entity strikeId _)) = do
+      mObserved <- selectFirst
+        ( (V1.BlockTimeStrikeObservedStrike ==. strikeId)
+        : observedStaticFilter
+        )
+        []
+      return [(guessE, strikeE, mObserved)]
+    maybeFetchCalculatedGuessesCount
+      :: ( Entity V1.BlockTimeStrikeGuess
+         , Entity V1.BlockTimeStrike
+         , Maybe (Entity V1.BlockTimeStrikeObserved)
+         )
+      -> ReaderT SqlBackend (NoLoggingT (ResourceT IO))
+         [ ( Entity V1.BlockTimeStrikeGuess
+           , Entity V1.BlockTimeStrike
+           , Maybe (Entity V1.BlockTimeStrikeObserved)
+           , Entity V1.CalculatedBlockTimeStrikeGuessesCount
+           )
+         ]
+    maybeFetchCalculatedGuessesCount
+        ( guessE
+        , strikeE@(Entity strikeId _)
+        , observedE
+        ) = do
+      maybe [] (\calculatedE -> [(guessE, strikeE, observedE, calculatedE)])
+        <$> selectFirst
+          [V1.CalculatedBlockTimeStrikeGuessesCountStrike ==. strikeId]
+          []
+    coerceFilterRequestBlockTimeStrike
+      :: APIV1.BuildFilter V1.BlockTimeStrike a
+      => APIV1.FilterRequest BlockSpanTimeStrikeGuess a
+      -> APIV1.FilterRequest V1.BlockTimeStrike a
+    coerceFilterRequestBlockTimeStrike = APIV1.FilterRequest
+      . (\(f, _)-> (f, Proxy))
+      . APIV1.unFilterRequest
+    mfilter = fmap coerceFilterRequestBlockTimeStrike mfilterAPI
+    coerceFilterRequestBlockTimeStrikeGuess
+      :: APIV1.BuildFilter V1.BlockTimeStrikeGuess a
+      => APIV1.FilterRequest BlockSpanTimeStrikeGuess a
+      -> APIV1.FilterRequest V1.BlockTimeStrikeGuess a
+    coerceFilterRequestBlockTimeStrikeGuess = APIV1.FilterRequest
+      . (\(f, _)-> (f, Proxy))
+      . APIV1.unFilterRequest
+    mfilterGuess = fmap coerceFilterRequestBlockTimeStrikeGuess mfilterAPI
+    coerceFilterRequestBlockTimeStrikeObserved
+      :: APIV1.BuildFilter V1.BlockTimeStrikeObserved a
+      => APIV1.FilterRequest BlockSpanTimeStrikeGuess a
+      -> APIV1.FilterRequest V1.BlockTimeStrikeObserved a
+    coerceFilterRequestBlockTimeStrikeObserved = APIV1.FilterRequest
+      . (\(f, _)-> (f, Proxy))
+      . APIV1.unFilterRequest
+    mfilterObserved = fmap coerceFilterRequestBlockTimeStrikeObserved mfilterAPI
+    observedStaticFilter = maybe
+      []
+      ( APIV1.buildFilter
+      . APIV1.unFilterRequest
+      . APIV1.mapFilter
+      )
+      mfilterObserved
+    strikeStaticPartFilter = maybe
+      []
+      ( APIV1.buildFilter
+      . APIV1.unFilterRequest
+      . APIV1.mapFilter
+      )
+      mfilter
+    guessStaticPartFilter = maybe
+      []
+      ( APIV1.buildFilter
+      . APIV1.unFilterRequest
+      . APIV1.mapFilter
+      )
+      mfilterGuess
+    sort = maybe
+             Descend
+             ( APIV1.sortOrder
+             . APIV1.unFilterRequest
+             )
+             mfilter
+


### PR DESCRIPTION
This PR introduced GET `/api/v2/blockrate/strikes/guesses` to get user's guesses for all strikes.

Supports filter by:
- `guess`
- `strike` (mediantime, height)
- `observed strike` (hash and observed result)




