### PR TITLE
feat: pin nixpkgs to NixOS 22.05

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,6 @@
 let
-  pkgs = (import <nixpkgs> {
+  stable = import ./nixpkgs.nix;
+  pkgs = (import stable {
     overlays = [ (import ./overlay.nix { GIT_COMMIT_HASH = ""; } ) ];
   }); # first, load the nixpkgs with system-wide overlays
 in pkgs.op-energy

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,0 +1,1 @@
+fetchTarball "https://github.com/NixOS/nixpkgs/archive/4d2b37a84fad1091b9de401eb450aae66f1a741e.tar.gz"

--- a/oe-account-service/op-energy-account-service/default.nix
+++ b/oe-account-service/op-energy-account-service/default.nix
@@ -1,6 +1,8 @@
+{ GIT_COMMIT_HASH ? ""
+}:
 let
   stable = import ../../nixpkgs.nix;
-  overlay = import ../../overlay.nix { GIT_COMMIT_HASH = "";};
+  overlay = import ../../overlay.nix { GIT_COMMIT_HASH = GIT_COMMIT_HASH;};
   pkgs = (import stable {
     overlays = [ overlay ];
   }); # first, load the nixpkgs with system-wide overlays

--- a/oe-account-service/op-energy-account-service/default.nix
+++ b/oe-account-service/op-energy-account-service/default.nix
@@ -1,0 +1,8 @@
+let
+  stable = import ../../nixpkgs.nix;
+  overlay = import ../../overlay.nix { GIT_COMMIT_HASH = "";};
+  pkgs = (import stable {
+    overlays = [ overlay ];
+  }); # first, load the nixpkgs with system-wide overlays
+
+in pkgs.op-energy-account-service

--- a/oe-account-service/op-energy-account-service/shell.nix
+++ b/oe-account-service/op-energy-account-service/shell.nix
@@ -1,6 +1,7 @@
 let
+  stable = import ../../nixpkgs.nix;
   overlay = import ../../overlay.nix { GIT_COMMIT_HASH = "";};
-  pkgs = (import <nixpkgs> {
+  pkgs = (import stable {
     overlays = [ overlay ];
   }); # first, load the nixpkgs with system-wide overlays
   shell = pkgs.stdenv.mkDerivation {

--- a/overlay-set.nix
+++ b/overlay-set.nix
@@ -8,8 +8,8 @@ let
   op-energy-backend-overlay = import ./oe-blockspan-service/op-energy-backend/overlay.nix {
     GIT_COMMIT_HASH = GIT_COMMIT_HASH;
   };
-  nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/archive/4d2b37a84fad1091b9de401eb450aae66f1a741e.tar.gz";
-  pkgs = import nixpkgs {
+  stable = import ./nixpkgs.nix;
+  pkgs = import stable {
     config = {};
     overlays = [
       op-energy-api-overlay


### PR DESCRIPTION
This PR contains pinned nixpkgs for reproducible builds.

Main purpose are:

- to be able to build and deploy op-energy on a current NixOS version without rewriting big portion of code due to dependencies updates;
- to update instances to the current nixos versions;
- to be able to update op-energy dependencies in the future.