### PR TITLE
82 update nixos modules to current nixos version

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -26,8 +26,7 @@ jobs:
     - run: git remote -v
     - run: echo ${{ github.ref_name }}
     - run: git checkout -b devel
-    - run: git submodule set-branch -b devel oe-blockspan-service && git submodule update --remote --recursive
     - run: git config user.name "dev-deploy"; git config user.email "dev@dev.deploy"; git commit -a -m "switch to branch devel"
     - run: git push --force -u origin devel
-    - run: ssh -oStrictHostKeyChecking=no root@${{ vars.DEV_INSTANCE }} "cd /etc/nixos; git pull --rebase; git submodule update --remote --recursive; systemctl stop op-energy-backend-mainnet.service op-energy-account-service.service && nixos-rebuild switch; systemctl start op-energy-backend-mainnet.service op-energy-account-service.service"
+    - run: ssh -oStrictHostKeyChecking=no root@${{ vars.DEV_INSTANCE }} "cd /etc/nixos; git pull --rebase; git submodule update --init --remote --recursive; systemctl stop op-energy-backend-mainnet.service op-energy-account-service.service && nixos-rebuild switch && nix-collect-garbage -d; systemctl start op-energy-backend-mainnet.service op-energy-account-service.service"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,12 +18,11 @@ jobs:
         extra_nix_config: "system-features = nixos-test benchmark big-parallel kvm"
     - run: git clone ssh://git@github.com/op-energy-foundation/op-energy-dev-instance.git ../op-energy-dev-instance --recursive --remote -b devel
     # current repo's use case is to be submodule in 80% of cases, so we need to copy content of op-energy repo into a proper submodule location
-    - run: rm -rf oe-blockspan-service && cp -rf ../op-energy-dev-instance/overlays/op-energy/oe-blockspan-service ./
-    - run: git submodule update --remote
+    - run: git submodule update --remote --init --recursive
     - run: rm -rf ../op-energy-dev-instance/overlays/op-energy/* && cp -r $(pwd)/* ../op-energy-dev-instance/overlays/op-energy/
     - run: echo \"ci-host\" > ../op-energy-dev-instance/local_hostname.nix
     # ci-tests.nix should be on the same level as op-energy-dev-instance
-    - run: cp ./oe-blockspan-service/ci-tests.nix ../
+    - run: cp ../op-energy-dev-instance/overlays/op-energy-blockspan-service/ci-tests.nix ../
     # now actually run the builds and tests with passing git commit hash as an argument
     - run: cd ../ && nix-build ci-tests.nix --argstr GIT_COMMIT_HASH $( echo ${{github.sha}} | cut -c 1-8 )
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "oe-blockspan-service"]
-	path = oe-blockspan-service
-	url = ssh://git@github.com/op-energy-foundation/op-energy-blockspan-service

--- a/README.md
+++ b/README.md
@@ -7,42 +7,100 @@ Another way is to copy-past the content into https://stackedit.io
 
 We use nix package manager for deployment. Our primary target is NixOS, but you can use nix to build OpEnergy on any OS supporting Nix and then setup OS-specific system services yourself.
 
-## How to install on NixOS
+## How to install NixOS
+
+Installing NixOS is an offtopic here, but here is a short version just to provide you a vector
+
+### Get NixOS ISO from website
+
+Go to https://nixos.org and get the ISO image.
+Download it to your iso location, boot from it into live os and login into
+terminal shell
+
+### Format the storage and install OS
+
+WARNING! This will erase all your data on the disk!
+
+Assuming, that your drive for OS is /dev/vda, issue in terminal:
+
+```
+export DISK=/dev/vda
+dd if=/dev/zero of=$DISK bs=1M count=1000
+sudo sfdisk -f $DISK <<EOF
+label: dos
+, 2G, S
+, 500M, L, *
+, , L
+EOF
+mkswap ${DISK}1
+swapon ${DISK}1
+mkfs.ext4 ${DISK}2
+mkfs.xfs -f -mreflink=1 ${DISK}3
+mkdir -p /mnt/
+mount ${DISK}3 /mnt
+mkdir -p /mnt/boot
+mount ${DISK}2 /mnt/boot
+nixos-generate-config --root /mnt
+sed -i 's/# services.openssh.enable = true;/services.openssh.enable = true;/' /mnt/etc/nixos/configuration.nix
+sed -i 's/# environment.systemPackages = with pkgs; \[/environment.systemPackages = with pkgs; \[ wget vim git \];/' /mnt/etc/nixos/configuration.nix
+sed -i 's/# boot.loader.grub.device = "\/dev\/sda";/boot.loader.grub.device = "\/dev\/vda";/' /mnt/etc/nixos/configuration.nix
+sed -i 's/# boot.loader.grub.efiSupport = true;/boot.loader.grub.efiSupport = false;/' /mnt/etc/nixos/configuration.nix
+sed -i 's/# users.users.alice = {/users.users.user = { isNormalUser = true; extraGroups = \[ "wheel" \];};/' /mnt/etc/nixos/configuration.nix
+nixos-install --root /mnt
+echo "set a password for user 'user'"
+nixos-enter --root /mnt -- passwd user
+reboot
+```
+
+https://channels.nixos.org/nixos-26.05/latest-nixos-minimal-x86_64-linux.iso
+
+### Login into installed OS
+
+After reboot, login with user 'user' with the last password you provided
+
+## How to install on an already existing NixOS
 
 As NixOS is our primary target, you just need to:
 
-1. clone OpEnergy repo:
+1. clone OpEnergy repos:
 
 ```
 sudo -i
 mkdir -p /etc/nixos/overlays
 git clone https://github.com/op-energy-foundation/op-energy --recursive /etc/nixos/overlays/op-energy
+git clone https://github.com/op-energy-foundation/op-energy-blockspan-service --recursive /etc/nixos/overlays/op-energy-blockspan-service
+git clone https://github.com/op-energy-foundation/op-energy-frontend --recursive /etc/nixos/overlays/op-energy-frontend
 ```
 
 2. generate random secrets with
 
 ```
 sudo mkdir -p /etc/nixos/private
-cd op-energy/oe-blockspan-service/op-energy-backend/
-sudo nix-shell shell.nix
+cd /etc/nixos/overlays/op-energy-blockspan-service/op-energy-backend/
+sudo nix-shell gen-psk-shell.nix
 ./gen-psk.sh /etc/nixos/private mainnet
 ```
 
-3. add config to `/etc/nixos/configuration.nix`
+3. add config to `/etc/nixos/op-energy.nix`
 
 ```
-args@{ pkgs
-, lib
-, config
-, GIT_COMMIT_HASH ? ""
-, OP_ENERGY_REPO_LOCATION ? /etc/nixos/.git/modules/overlays/op-energy/modules/oe-blockspan-service
-, OP_ENERGY_ACCOUNT_REPO_LOCATION ? /etc/nixos/.git/modules/overlays/op-energy
+cat > /etc/nixos/op-energy.nix <<EOF
+env@{ GIT_COMMIT_HASH ? ""
+, OP_ENERGY_REPO_LOCATION ? /etc/nixos/overlays/op-energy-blockspan-service/.git
+, OP_ENERGY_FRONTEND_REPO_LOCATION ? /etc/nixos/overlays/op-energy-frontend/.git
+, OP_ENERGY_ACCOUNT_REPO_LOCATION ? /etc/nixos/overlays/op-energy/.git
   # import psk from out-of-git file
 , bitcoind-mainnet-rpc-psk ? builtins.readFile ( "/etc/nixos/private/bitcoind-mainnet-rpc-psk.txt")
 , bitcoind-mainnet-rpc-pskhmac ? builtins.readFile ( "/etc/nixos/private/bitcoind-mainnet-rpc-pskhmac.txt")
 , op-energy-db-psk-mainnet ? builtins.readFile ( "/etc/nixos/private/op-energy-db-psk-mainnet.txt")
 , op-energy-db-salt-mainnet ? builtins.readFile ( "/etc/nixos/private/op-energy-db-salt-mainnet.txt")
 , op-energy-account-token-encryption-key ? builtins.readFile ( "/etc/nixos/private/op-energy-account-token-encryption-key.txt")
+, ...
+}:
+
+args@{ pkgs
+, lib
+, config
 , ...
 }:
 
@@ -57,13 +115,15 @@ let
       pkgs.runCommand "get-rev1" {
         nativeBuildInputs = [ pkgs.git ];
       } ''
-        echo "OP_ENERGY_REPO_LOCATION = ${REPO_LOCATION}"
-        HASH=$(cat ${sourceWithGit}/HEAD | cut -c 1-8 | tr -d '\n' || printf 'NOT A GIT REPO')
-        printf $HASH > $out
+        echo "OP_ENERGY_REPO_LOCATION = \${REPO_LOCATION}"
+        REF=\$(cat \${sourceWithGit}/HEAD | awk '{ print \$2}')
+        HASH_FILE=\$(cat \${sourceWithGit}/\$REF)
+        HASH=\$(echo \$HASH_FILE | cut -c 1-8 | tr -d '\n' || printf 'NOT A GIT REPO')
+        printf \$HASH > \$out
       ''
     );
-  opEnergyFrontendModule = import ./overlays/op-energy/oe-blockspan-service/frontend/module-frontend.nix { GIT_COMMIT_HASH = GIT_COMMIT_HASH OP_ENERGY_REPO_LOCATION; };
-  opEnergyBackendModule = import ./overlays/op-energy/oe-blockspan-service/op-energy-backend/module-backend.nix { GIT_COMMIT_HASH = GIT_COMMIT_HASH OP_ENERGY_REPO_LOCATION; };
+  opEnergyFrontendModule = import ./overlays/op-energy-frontend/frontend/module-frontend.nix { GIT_COMMIT_HASH = GIT_COMMIT_HASH OP_ENERGY_FRONTEND_REPO_LOCATION; };
+  opEnergyBackendModule = import ./overlays/op-energy-blockspan-service/op-energy-backend/module-backend.nix { GIT_COMMIT_HASH = GIT_COMMIT_HASH OP_ENERGY_REPO_LOCATION; };
   opEnergyAccountServiceModule = import ./overlays/op-energy/oe-account-service/op-energy-account-service/module-backend.nix { GIT_COMMIT_HASH = GIT_COMMIT_HASH OP_ENERGY_ACCOUNT_REPO_LOCATION; };
 in
 {
@@ -88,7 +148,7 @@ in
     rpc.users = {
       op-energy = {
         name = "op-energy";
-        passwordHMAC = "${bitcoind-mainnet-rpc-pskhmac}";
+        passwordHMAC = "\${bitcoind-mainnet-rpc-pskhmac}";
       };
     };
   };
@@ -106,14 +166,14 @@ in
         {
           "DB_PORT": 5432,
           "DB_HOST": "127.0.0.1",
-          "DB_USER": "${db}",
-          "DB_NAME": "${db}",
-          "DB_PASSWORD": "${op-energy-db-psk-mainnet}",
-          "SECRET_SALT": "${op-energy-db-salt-mainnet}",
+          "DB_USER": "\${db}",
+          "DB_NAME": "\${db}",
+          "DB_PASSWORD": "\${op-energy-db-psk-mainnet}",
+          "SECRET_SALT": "\${op-energy-db-salt-mainnet}",
           "API_HTTP_PORT": 8999,
-          "BTC_URL": "http://127.0.0.1:8332", # in case of using another node, define it's address and credentials
-          "BTC_USER": "op-energy", # and here
-          "BTC_PASSWORD": "${bitcoind-mainnet-rpc-psk}", # and here as well
+          "BTC_URL": "http://127.0.0.1:8332",
+          "BTC_USER": "op-energy",
+          "BTC_PASSWORD": "\${bitcoind-mainnet-rpc-psk}",
           "BTC_POLL_RATE_SECS": 10,
           "PROMETHEUS_PORT": 7999,
           "SCHEDULER_POLL_RATE_SECS": 10
@@ -133,9 +193,9 @@ in
         "DB_HOST": "127.0.0.1",
         "DB_USER": "openergy",
         "DB_NAME": "openergyacc",
-        "DB_PASSWORD": "${op-energy-db-psk-mainnet}",
-        "SECRET_SALT": "${op-energy-db-salt-mainnet}",
-        "ACCOUNT_TOKEN_ENCRYPTION_PRIVATE_KEY": "${op-energy-account-token-encryption-key}",
+        "DB_PASSWORD": "\${op-energy-db-psk-mainnet}",
+        "SECRET_SALT": "\${op-energy-db-salt-mainnet}",
+        "ACCOUNT_TOKEN_ENCRYPTION_PRIVATE_KEY": "\${op-energy-account-token-encryption-key}",
         "API_HTTP_PORT": 8899,
         "PROMETHEUS_PORT": 7899,
         "LOG_LEVEL_MIN": "Debug",
@@ -154,16 +214,51 @@ in
     80
   ];
 }
-
+EOF
+sed -i 's=./hardware-configuration.nix$=./hardware-configuration.nix \(import .\/op-energy.nix {}\)=' /etc/nixos/configuration.nix
 ```
 
-4. rebuild config:
+4. (optional) change connection options to Bitcoin node
+
+Edit file `/etc/nixos/op-energy.nix` with your favourite text editor and adjust
+those options as you need:
+
+```
+"BTC_URL": "http://127.0.0.1:8332", # in case of using another node, define it's address and credentials
+"BTC_USER": "op-energy", # and here
+"BTC_PASSWORD": "\${bitcoind-mainnet-rpc-psk}", # and here as well
+```
+
+in this case you should disable local bitcoind instance as well by changing:
+
+```
+  services.bitcoind.mainnet = {
+    enable = true;
+```
+
+to `false`.
+
+5. rebuild config:
 
 ```
 nixos-rebuild switch
 ```
 
 this command will build and enable all the services
+
+6. wait for initial block header sync
+
+You can check logs of the blockspan service while it will be fetching block
+header data using this command:
+
+```
+journalctl -f -u op-energy-blockspan-service
+```
+
+it will take a while, especially if you are using local bitcoin node
+After the initial sync of the bitcoin node and of the blockspan services, HTTP
+service will appear at `http://<VM_IP>:80`
+
 
 ## How to build
 
@@ -178,7 +273,23 @@ We provide 3 services at the moment:
 2. frontend;
 3. account + blocktime service.
 
-#### building blockspan + frontend service
+#### building frontend
+
+clone repo with
+
+```
+git clone https://github.com/op-energy-foundation/op-energy-frontend
+```
+then build with `nix-build`:
+
+```
+cd op-energy-frontend/frontend
+nix-build default.nix
+```
+
+both folders will have symlink called `result`, which contain compiled binaries
+
+#### building blockspan service
 
 clone repo with
 
@@ -188,10 +299,7 @@ git clone https://github.com/op-energy-foundation/op-energy-blockspan-service
 then build with `nix-build`:
 
 ```
-cd op-energy-blockspan-service/frontend
-nix-build default.nix -A op-energy-frontend
-
-cd ../op-energy-backend
+cd op-energy-blockspan-service/op-energy-backend
 nix-build default.nix
 ```
 

--- a/oe-account-service/op-energy-account-service/module-backend.nix
+++ b/oe-account-service/op-energy-account-service/module-backend.nix
@@ -14,6 +14,7 @@ let
     $$
     ;
     ALTER USER ${cfg.db_user} WITH PASSWORD '${cfg.db_psk}';
+    GRANT ALL PRIVILEGES ON DATABASE ${cfg.db_name} TO ${cfg.db_user};
   '';
 
   cfg = config.services.op-energy-account-service;
@@ -111,12 +112,9 @@ in
     services.postgresql = {
       enable = true;
       ensureDatabases = [ "${cfg.db_name}" ];
-      ensureUsers = [ {
-        name = "${cfg.db_user}";
-        ensurePermissions = {
-          "DATABASE ${cfg.db_name}" = "ALL PRIVILEGES";
-        };
-      } ];
+      ensureUsers =
+        [ { name = "${cfg.db_user}"; }
+        ];
     };
     systemd.services = {
       postgresql-op-energy-users = {

--- a/oe-account-service/op-energy-account-service/module-backend.nix
+++ b/oe-account-service/op-energy-account-service/module-backend.nix
@@ -10,11 +10,12 @@ let
       if not exists (select * from pg_user where usename = '${cfg.db_user}') then
         CREATE USER ${cfg.db_user} WITH PASSWORD '${cfg.db_psk}';
       end if;
+      ALTER USER ${cfg.db_user} WITH PASSWORD '${cfg.db_psk}';
+      GRANT ALL PRIVILEGES ON DATABASE ${cfg.db_name} TO ${cfg.db_user};
+      ALTER DATABASE ${cfg.db_name} OWNER TO ${cfg.db_user};
     end
     $$
     ;
-    ALTER USER ${cfg.db_user} WITH PASSWORD '${cfg.db_psk}';
-    GRANT ALL PRIVILEGES ON DATABASE ${cfg.db_name} TO ${cfg.db_user};
   '';
 
   cfg = config.services.op-energy-account-service;
@@ -117,7 +118,7 @@ in
         ];
     };
     systemd.services = {
-      postgresql-op-energy-users = {
+      postgresql-op-energy-account-users = {
         wantedBy = [ "multi-user.target" ];
         after = [
           "postgresql.service"

--- a/oe-account-service/op-energy-account-service/module-backend.nix
+++ b/oe-account-service/op-energy-account-service/module-backend.nix
@@ -148,12 +148,12 @@ in
       in {
         wantedBy = [ "multi-user.target" ];
         after = [
-          "network-setup.service"
+          "network-online.target"
           "postgresql.service"
         ];
         requires = [
-          "network-setup.service"
           "postgresql.service"
+          "network-online.target"
           ];
         serviceConfig = {
           Type = "simple";

--- a/oe-account-service/op-energy-account-service/shell.nix
+++ b/oe-account-service/op-energy-account-service/shell.nix
@@ -10,6 +10,7 @@ let
       = pkgs.op-energy-account-service.env.nativeBuildInputs
       ++ pkgs.op-energy-account-service.buildInputs
       ++ [ pkgs.haskellPackages.swagger2 pkgs.haskellPackages.servant pkgs.haskellPackages.servant-swagger
+           pkgs.haskell-language-server
          ]
       ++ [ pkgs.haskellPackages.ghci pkgs.haskellPackages.ghcid pkgs.haskellPackages.cabal-install ];
   };

--- a/overlay-set.nix
+++ b/overlay-set.nix
@@ -1,19 +1,21 @@
 {GIT_COMMIT_HASH}:
 let
-  op-energy-api-overlay = import ./oe-blockspan-service/op-energy-api/overlay.nix;
+  op-energy-blockspan-service-api-overlay =
+    import ../op-energy-blockspan-service/op-energy-api/overlay.nix;
+  op-energy-blockspan-service-overlay =
+    import ../op-energy-blockspan-service/op-energy-backend/overlay.nix {
+      GIT_COMMIT_HASH = GIT_COMMIT_HASH;
+    };
   op-energy-account-api-overlay = import ./oe-account-service/op-energy-account-api/overlay.nix;
   op-energy-account-service-overlay = import ./oe-account-service/op-energy-account-service/overlay.nix {
-    GIT_COMMIT_HASH = GIT_COMMIT_HASH;
-  };
-  op-energy-backend-overlay = import ./oe-blockspan-service/op-energy-backend/overlay.nix {
     GIT_COMMIT_HASH = GIT_COMMIT_HASH;
   };
   stable = import ./nixpkgs.nix;
   pkgs = import stable {
     config = {};
     overlays = [
-      op-energy-api-overlay
-      op-energy-backend-overlay
+      op-energy-blockspan-service-api-overlay
+      op-energy-blockspan-service-overlay
       op-energy-account-api-overlay
       op-energy-account-service-overlay
     ];


### PR DESCRIPTION
This PR's goal is to make op-energy account and blockrate services be compatible with NixOS 26.05

It contains:
1. compatibility with NixOS 26.05;
2. git submodule oe-blockspan-service had been removed. Now it is assumed, that there exist `../op-energy-blockspan-service/op-energy-api/overlay.nix`. This is basically the same way as `op-energy-frontend` repo is located. This change makes easier to use custom branches when testing local setups, for example, within nixos-container.